### PR TITLE
Adds encoding for csv files

### DIFF
--- a/serenata_toolbox/ceap_dataset.py
+++ b/serenata_toolbox/ceap_dataset.py
@@ -147,6 +147,7 @@ class CEAPDataset:
                       for cat in data['subquota_description'].cat.categories]
         data['subquota_description'].cat.rename_categories(categories,
                                                            inplace=True)
-        data.to_csv(output_file_path, compression='xz', index=False)
+        data.to_csv(output_file_path, compression='xz', index=False,
+                    encoding='utf-8')
 
         return output_file_path

--- a/serenata_toolbox/xml2csv.py
+++ b/serenata_toolbox/xml2csv.py
@@ -73,7 +73,7 @@ def convert_xml_to_csv(xml_file_path, csv_file_path):
         writer.writerow(json.loads(json_io.getvalue()))
 
         output('Writing record #{:,} to the CSV'.format(count), end='\r')
-        with open(csv_file_path, 'a') as csv_file:
+        with open(csv_file_path, 'a', encoding='utf-8') as csv_file:
             print(csv_io.getvalue(), file=csv_file)
 
         json_io.close()


### PR DESCRIPTION
By setting the expected encoding for the csv files we can make sure that even with `locale` not set up people can run the scripts.