### PR TITLE
Refactor datasets module: enhancements in terms of UX & async

### DIFF
--- a/serenata_toolbox/datasets.py
+++ b/serenata_toolbox/datasets.py
@@ -58,7 +58,6 @@ class Downloader:
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.main(loop, files))
-        loop.close()
 
     async def main(self, loop, files):
         if len(files) == 1:

--- a/serenata_toolbox/datasets.py
+++ b/serenata_toolbox/datasets.py
@@ -1,22 +1,18 @@
+import asyncio
 import os
-from urllib.request import urlretrieve
+
+import aiofiles
+import aiohttp
+from tqdm import tqdm
+
+AWS_BUCKET = 'serenata-de-amor-data'
+AWS_REGION = 's3-sa-east-1'
+MAX_REQUESTS = 4
 
 
-def fetch(filename, destination_path,
-          aws_bucket='serenata-de-amor-data',
-          aws_region='s3-sa-east-1'):
-    url = 'https://{}.amazonaws.com/{}/{}'.format(aws_region,
-                                                  aws_bucket,
-                                                  filename)
-    filepath = os.path.join(destination_path, filename)
-    if not os.path.exists(filepath):
-        urlretrieve(url, filepath)
+class Downloader:
 
-
-def fetch_latest_backup(destination_path,
-                        aws_bucket='serenata-de-amor-data',
-                        aws_region='s3-sa-east-1'):
-    files = (
+    LATEST = (
         '2016-08-08-ceap-datasets.md',
         '2016-08-08-current-year.xz',
         '2016-08-08-datasets-format.html',
@@ -43,5 +39,82 @@ def fetch_latest_backup(destination_path,
         '2017-03-15-reimbursements.xz',
         '2017-03-20-purchase-suppliers.xz'
     )
-    for filename in files:
-        fetch(filename, destination_path, aws_bucket, aws_region)
+
+    def __init__(self, target, aws_bucket=None, aws_region=None):
+        self.aws_bucket = aws_bucket or AWS_BUCKET
+        self.aws_region = aws_region or AWS_REGION
+        self.target = os.path.abspath(target)
+        self.semaphore = asyncio.Semaphore(MAX_REQUESTS)
+        self.total = 0
+
+        if not all((os.path.exists(self.target), os.path.isdir(self.target))):
+            msg = '{} does not exist or is not a directory.'
+            raise FileNotFoundError(msg.format(self.target))
+
+    def download(self, files):
+        files = list(files)  # generator wouldn't work, we loop through them 2x
+        if not files:
+            return
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(self.main(loop, files))
+        loop.close()
+
+    async def main(self, loop, files):
+        if len(files) == 1:
+            desc = 'Downloading {}'.format(files[0])
+        else:
+            desc = 'Downloading {} files'.format(len(files))
+
+        async with aiohttp.ClientSession(loop=loop) as client:
+
+            # fetch total size (all files)
+            sizes = [self.fetch_size(client, filename) for filename in files]
+            await asyncio.gather(*sizes)
+
+            # download
+            args = dict(total=self.total, desc=desc, unit='b', unit_scale=True)
+            with tqdm(**args) as progress:
+                self.progress = progress
+                downloads = [self.fetch_file(client, f) for f in files]
+                await asyncio.gather(*downloads)
+
+            # cleanup
+            del self.progress
+            self.total = 0
+
+    async def fetch_size(self, client, filename):
+        url = self.url(filename)
+
+        with (await self.semaphore):
+            async with client.head(url) as response:
+                size = response.headers.get('CONTENT-LENGTH', '0')
+
+        self.total += int(size)
+
+    async def fetch_file(self, client, filename):
+        filepath = os.path.join(self.target, filename)
+        url = self.url(filename)
+
+        with (await self.semaphore):
+            async with client.get(url, timeout=None) as response:
+                contents = await response.read()
+
+                async with aiofiles.open(filepath, 'wb') as fh:
+                    await fh.write(contents)
+
+                self.progress.update(len(contents))
+
+    def url(self, filename):
+        url = 'https://{}.amazonaws.com/{}/{}'
+        return url.format(self.aws_region, self.aws_bucket, filename)
+
+
+def fetch(filename, destination_path, aws_bucket=None, aws_region=None):
+    downloader = Downloader(destination_path, aws_bucket, aws_region)
+    return downloader.download([filename])
+
+
+def fetch_latest_backup(destination_path, aws_bucket=None, aws_region=None):
+    downloader = Downloader(destination_path, aws_bucket, aws_region)
+    return downloader.download(downloader.LATEST)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
     name='serenata-toolbox',
     packages=['serenata_toolbox'],
     url=REPO_URL,
-    version='0.0.1'
+    version='7.5.1'
 )

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,12 @@ setup(
     ],
     description='Toolbox for Serenata de Amor project',
     install_requires=[
+        'aiofiles',
+        'aiohttp',
         'beautifulsoup4>=4.4',
         'lxml>=3.6',
         'pandas>=0.18',
+        'tqdm'
     ],
     keywords='serenata de amor, data science, brazil, corruption',
     license='MIT',


### PR DESCRIPTION
This PR refactors `datasets` modules without changing it's public API — `serenata_toolbox.datasets.fetch(…)` and `serenata_toolbox.datasets.fetch_latest_backup(…)` still works as it used to work before.

There are two improvements: use of async methods to download multiple files in parallel and a better UX (a progress bar with the total size of the download and the progress).

<img width="649" alt="untitled 3" src="https://cloud.githubusercontent.com/assets/4732915/24470142/4a1e2b80-1494-11e7-9605-9e2c1bdb5985.png">