### PR TITLE
Add module to manage datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.egg-info/
 *.pyc
+.coverage
 __pycache__/
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.pyc
 .coverage
 __pycache__/
+config.ini
 htmlcov/

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,8 @@ serenata_toolbox is compatible with Python 3+
 Usage
 -----
 
+If you plan to upload data to a S3 server you should copy `config.ini.example` as `config.ini` and edit it with your own credentials.
+
 .. code:: python
 
   $ python3

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,5 @@
+[Amazon]
+Bucket: serenata-de-amor-data
+AccessKey: YOUR_ACCESS_KEY
+Region: sa-east-1
+SecretKey: YOUR_SECRET_KEY

--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -7,19 +7,27 @@ from serenata_toolbox.datasets.remote import RemoteDatasets
 
 class Datasets:
     """
-    This is a wrapper for three different classes together handles the datasets
-    locally and remotelly.
+    This is a wrapper for three different classes that together handle the
+    datasets (locally and remotelly).
 
-    Inside the instantiated object there are three main objects: local, remote,
-    and downloader:
+    Datasets class takes one argument: the path to the local directory of the
+    dataset files (e.g. data/ or /tmp/serenata-data). The argument is optional
+    and the default value is data/ (following the default usage in the main
+    repo, serenata-de-amor).
+
+    The remote part of the class expect to find Amazon credentials in a
+    config.ini file with an Amazon section (e.g. config.ini.exemple).
+
+    Inside it object there are three main objects: local, remote, and
+    downloader:
 
     * `Datasets.local` handles listing all local datasets through the property
-      `Datasets.local.all` and deleting local datasets with the method
-      `Datasets.local.delete(filename)`;
+      `Datasets.local.all` (hint: it's a generator) and deleting local datasets
+      with the method `Datasets.local.delete(filename)`;
 
-    * `Datasets.remote` has the `Datasets.remote.all` property and
-      `Dataset.remote.delete(filename)` method just like its local equivalent;
-      in addition to them this object offers the
+    * `Datasets.remote` has the `Datasets.remote.all` property (hint: it's also
+      a generator) and `Dataset.remote.delete(filename)` method just like its
+      local equivalent; in addition to them this object offers the
       `Datasets.remote.upload(file_path)` method to upload a local file to the
       remote bucket; `Datasets.remote` does not handles downloads because
       `boto3` does not support `asyncio` and we prefer to use async tasks to
@@ -31,12 +39,11 @@ class Datasets:
 
     Yet this wrapper implement the `Dataset.upload_all()` method to upload all
     local datasets that are not present in the remote bucket.
+
+    :param local_directory: (str) path to local directory of the datasets
     """
 
     def __init__(self, local_directory=None):
-        """
-        :param local_directory: (str) path to local directory of the datasets
-        """
         if not local_directory:
             local_directory = 'data'
 

--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -1,0 +1,73 @@
+import os
+
+from serenata_toolbox.datasets.downloader import Downloader
+from serenata_toolbox.datasets.local import LocalDatasets
+from serenata_toolbox.datasets.remote import RemoteDatasets
+
+
+class Datasets:
+    """
+    This is a wrapper for three different classes together handles the datasets
+    locally and remotelly.
+
+    Inside the instantiated object there are three main objects: local, remote,
+    and downloader:
+
+    * `Datasets.local` handles listing all local datasets through the property
+      `Datasets.local.all` and deleting local datasets with the method
+      `Datasets.local.delete(filename)`;
+
+    * `Datasets.remote` has the `Datasets.remote.all` property and
+      `Dataset.remote.delete(filename)` method just like its local equivalent;
+      in addition to them this object offers the
+      `Datasets.remote.upload(file_path)` method to upload a local file to the
+      remote bucket; `Datasets.remote` does not handles downloads because
+      `boto3` does not support `asyncio` and we prefer to use async tasks to
+      allow the download of more than one file in parallel;
+
+    * `Datasets.downloader` implements a async manager to download files from
+      the remote bucket. It's `Datasets.downloader.download(files)` take the
+      path for a single file (str) as argument or an iterable of paths (str).
+
+    Yet this wrapper implement the `Dataset.upload_all()` method to upload all
+    local datasets that are not present in the remote bucket.
+    """
+
+    def __init__(self, local_directory=None):
+        """
+        :param local_directory: (str) path to local directory of the datasets
+        """
+        if not local_directory:
+            local_directory = 'data'
+
+        self.local = LocalDatasets(local_directory)
+        self.remote = RemoteDatasets()
+        self.downloader = Downloader(
+            local_directory,
+            bucket=self.remote.bucket,
+            **self.remote.credentials
+        )
+
+    @property
+    def pending(self):
+        """Files that are in the local datasets but not in S3."""
+        local = set(self.local.all)
+        remote = set(self.remote.all)
+        yield from (local - remote)
+
+    def upload_all(self):
+        for file_name in self.pending:
+            full_path = os.path.join(self.local.directory, file_name)
+            self.remote.upload(full_path)
+
+
+# shortcuts & retrocompatibility
+
+def fetch(filename, destination_path):
+    datasets = Datasets(destination_path)
+    return datasets.downloader.download(filename)
+
+def fetch_latest_backup(destination_path):
+    datasets = Datasets(destination_path)
+    files = datasets.downloader.LATEST
+    return datasets.downloader.download(files)

--- a/serenata_toolbox/datasets/contextmanager.py
+++ b/serenata_toolbox/datasets/contextmanager.py
@@ -1,0 +1,8 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def status_message(message):
+    print(message, end=' ')
+    yield
+    print('Done!')

--- a/serenata_toolbox/datasets/downloader.py
+++ b/serenata_toolbox/datasets/downloader.py
@@ -5,8 +5,6 @@ import aiofiles
 import aiohttp
 from tqdm import tqdm
 
-AWS_BUCKET = 'serenata-de-amor-data'
-AWS_REGION = 's3-sa-east-1'
 MAX_REQUESTS = 4
 
 
@@ -40,19 +38,25 @@ class Downloader:
         '2017-03-20-purchase-suppliers.xz'
     )
 
-    def __init__(self, target, aws_bucket=None, aws_region=None):
-        self.aws_bucket = aws_bucket or AWS_BUCKET
-        self.aws_region = aws_region or AWS_REGION
-        self.target = os.path.abspath(target)
-        self.semaphore = asyncio.Semaphore(MAX_REQUESTS)
-        self.total = 0
+    def __init__(self, target, **kwargs):
+        self.bucket = kwargs.get('bucket')
+        self.region = kwargs.get('region_name')
+        if not all((self.bucket, self.region)):
+            raise RuntimeError('No bucket and/or region_name kwargs provided')
 
+        self.target = os.path.abspath(target)
         if not all((os.path.exists(self.target), os.path.isdir(self.target))):
             msg = '{} does not exist or is not a directory.'
             raise FileNotFoundError(msg.format(self.target))
 
+        self.semaphore = asyncio.Semaphore(MAX_REQUESTS)
+        self.total = 0
+
     def download(self, files):
-        files = list(files)  # generator wouldn't work, we loop through them 2x
+        if isinstance(files, str):
+            files = [files]
+
+        files = tuple(filter(bool, files))
         if not files:
             return
 
@@ -60,15 +64,15 @@ class Downloader:
         loop.run_until_complete(self.main(loop, files))
 
     async def main(self, loop, files):
+        desc = 'Downloading {} files'.format(len(files))
         if len(files) == 1:
-            desc = 'Downloading {}'.format(files[0])
-        else:
-            desc = 'Downloading {} files'.format(len(files))
+            first_file, *_ = files
+            desc = 'Downloading {}'.format(first_file)
 
         async with aiohttp.ClientSession(loop=loop) as client:
 
             # fetch total size (all files)
-            sizes = [self.fetch_size(client, filename) for filename in files]
+            sizes = [self.fetch_size(client, f) for f in files]
             await asyncio.gather(*sizes)
 
             # download
@@ -83,37 +87,23 @@ class Downloader:
             self.total = 0
 
     async def fetch_size(self, client, filename):
-        url = self.url(filename)
-
         with (await self.semaphore):
-            async with client.head(url) as response:
-                size = response.headers.get('CONTENT-LENGTH', '0')
+            async with client.head(self.url(filename)) as resp:
+                size = resp.headers.get('CONTENT-LENGTH', '0')
 
         self.total += int(size)
 
     async def fetch_file(self, client, filename):
         filepath = os.path.join(self.target, filename)
-        url = self.url(filename)
-
         with (await self.semaphore):
-            async with client.get(url, timeout=None) as response:
-                contents = await response.read()
+            async with client.get(self.url(filename), timeout=None) as resp:
+                contents = await resp.read()
 
-                async with aiofiles.open(filepath, 'wb') as fh:
-                    await fh.write(contents)
+            async with aiofiles.open(filepath, 'wb') as fh:
+                await fh.write(contents)
 
-                self.progress.update(len(contents))
+            self.progress.update(len(contents))
 
     def url(self, filename):
-        url = 'https://{}.amazonaws.com/{}/{}'
-        return url.format(self.aws_region, self.aws_bucket, filename)
-
-
-def fetch(filename, destination_path, aws_bucket=None, aws_region=None):
-    downloader = Downloader(destination_path, aws_bucket, aws_region)
-    return downloader.download([filename])
-
-
-def fetch_latest_backup(destination_path, aws_bucket=None, aws_region=None):
-    downloader = Downloader(destination_path, aws_bucket, aws_region)
-    return downloader.download(downloader.LATEST)
+        url = 'https://s3-{}.amazonaws.com/{}/{}'
+        return url.format(self.region, self.bucket, filename)

--- a/serenata_toolbox/datasets/local.py
+++ b/serenata_toolbox/datasets/local.py
@@ -13,7 +13,7 @@ class LocalDatasets:
 
     @property
     def all(self):
-        yield from filter(os.path.isfile, os.listdir(self.directory))
+        yield from filter(self._is_file, os.listdir(self.directory))
 
     def delete(self, file_name):
         full_path = os.path.join(self.directory, file_name)
@@ -22,3 +22,7 @@ class LocalDatasets:
 
         with status_message('Deleting {}…'.format(file_name)):
             os.remove(full_path)
+
+    def _is_file(self, filename):
+        full_path = os.path.join(self.directory, filename)
+        return os.path.isfile(full_path)

--- a/serenata_toolbox/datasets/local.py
+++ b/serenata_toolbox/datasets/local.py
@@ -1,0 +1,24 @@
+import os
+
+from serenata_toolbox.datasets.contextmanager import status_message
+
+
+class LocalDatasets:
+
+    def __init__(self, directory):
+        if not all((os.path.exists(directory), os.path.isdir(directory))):
+            raise FileNotFoundError('{} is not a directory'.format(directory))
+
+        self.directory = os.path.abspath(directory)
+
+    @property
+    def all(self):
+        yield from filter(os.path.isfile, os.listdir(self.directory))
+
+    def delete(self, file_name):
+        full_path = os.path.join(self.directory, file_name)
+        if not all((os.path.exists(full_path), os.path.isfile(full_path))):
+            raise FileNotFoundError('{} is not a flile'.format(full_path))
+
+        with status_message('Deleting {}…'.format(file_name)):
+            os.remove(full_path)

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -11,6 +11,8 @@ class RemoteDatasets:
     CONFIG = 'config.ini'
 
     def __init__(self):
+        self.s3, self.bucket = None, None
+
         if not all((os.path.exists(self.CONFIG), os.path.isfile(self.CONFIG))):
             print('Could not find {} file.'.format(self.CONFIG))
             print('You need Amzon section in it to interact with S3')

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -1,0 +1,34 @@
+import configparser
+import os
+
+import boto3
+
+from serenata_toolbox.datasets.contextmanager import status_message
+
+
+class RemoteDatasets:
+
+    def __init__(self):
+        self.settings = configparser.RawConfigParser()
+        self.settings.read('config.ini')
+        self.credentials = {
+            'aws_access_key_id': self.settings.get('Amazon', 'AccessKey'),
+            'aws_secret_access_key': self.settings.get('Amazon', 'SecretKey'),
+            'region_name': self.settings.get('Amazon', 'Region')
+        }
+        self.s3 = boto3.client('s3', **self.credentials)
+        self.bucket = self.settings.get('Amazon', 'Bucket')
+
+    @property
+    def all(self):
+        response =  self.s3.list_objects(Bucket=self.bucket)
+        yield from (obj.get('Key') for obj in response.get('Contents', []))
+
+    def upload(self, file_path):
+        _, file_name = os.path.split(file_path)
+        with status_message('Uploading {}…'.format(file_name)):
+            self.s3.upload_file(file_path, self.bucket, file_name)
+
+    def delete(self, file_name):
+        with status_message('Deleting {}…'.format(file_name)):
+            self.s3.delete_object(Bucket=self.bucket, Key=file_name)

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -8,27 +8,48 @@ from serenata_toolbox.datasets.contextmanager import status_message
 
 class RemoteDatasets:
 
+    CONFIG = 'config.ini'
+
     def __init__(self):
+        if not all((os.path.exists(self.CONFIG), os.path.isfile(self.CONFIG))):
+            print('Could not find {} file.'.format(self.CONFIG))
+            print('You need Amzon section in it to interact with S3')
+            print('(Check config.ini.example if you need a reference.)')
+            return
+
         self.settings = configparser.RawConfigParser()
-        self.settings.read('config.ini')
-        self.credentials = {
-            'aws_access_key_id': self.settings.get('Amazon', 'AccessKey'),
-            'aws_secret_access_key': self.settings.get('Amazon', 'SecretKey'),
-            'region_name': self.settings.get('Amazon', 'Region')
-        }
-        self.s3 = boto3.client('s3', **self.credentials)
-        self.bucket = self.settings.get('Amazon', 'Bucket')
+        self.settings.read(self.CONFIG)
+
+        try:
+            self.credentials = dict(
+                aws_access_key_id=self.settings.get('Amazon', 'AccessKey'),
+                aws_secret_access_key=self.settings.get('Amazon', 'SecretKey'),
+                region_name=self.settings.get('Amazon', 'Region')
+            )
+            self.bucket = self.settings.get('Amazon', 'Bucket')
+
+        except configparser.NoSectionError:
+            msg = 'You need Amzon section in {}  to interact with S3'
+            print(msg.format(self.CONFIG))
+            print('(Check config.ini.example if you need a reference.)')
+            return
+
+        else:
+            self.s3 = boto3.client('s3', **self.credentials)
 
     @property
     def all(self):
-        response =  self.s3.list_objects(Bucket=self.bucket)
-        yield from (obj.get('Key') for obj in response.get('Contents', []))
+        if self.s3 and self.bucket:
+            response =  self.s3.list_objects(Bucket=self.bucket)
+            yield from (obj.get('Key') for obj in response.get('Contents', []))
 
     def upload(self, file_path):
-        _, file_name = os.path.split(file_path)
-        with status_message('Uploading {}…'.format(file_name)):
-            self.s3.upload_file(file_path, self.bucket, file_name)
+        if self.s3 and self.bucket:
+            _, file_name = os.path.split(file_path)
+            with status_message('Uploading {}…'.format(file_name)):
+                self.s3.upload_file(file_path, self.bucket, file_name)
 
     def delete(self, file_name):
-        with status_message('Deleting {}…'.format(file_name)):
-            self.s3.delete_object(Bucket=self.bucket, Key=file_name)
+        if self.s3 and self.bucket:
+            with status_message('Deleting {}…'.format(file_name)):
+                self.s3.delete_object(Bucket=self.bucket, Key=file_name)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     install_requires=[
         'aiofiles',
         'aiohttp',
+        'boto3',
         'beautifulsoup4>=4.4',
         'lxml>=3.6',
         'pandas>=0.18',

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     name='serenata-toolbox',
     packages=['serenata_toolbox'],
     url=REPO_URL,
-    version='7.5.1'
+    version='8.0.0'
 )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,85 @@
+import os
+from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
+
+from serenata_toolbox.datasets import Datasets, fetch, fetch_latest_backup
+
+
+class TestDatasets(TestCase):
+
+    @patch('serenata_toolbox.datasets.LocalDatasets')
+    @patch('serenata_toolbox.datasets.RemoteDatasets')
+    @patch('serenata_toolbox.datasets.Downloader')
+    def test_init_without_local_directory(self, downloader, remote, local):
+        remote.return_value.bucket = 'mybucket'
+        remote.return_value.credentials = dict(user='user', password='password')
+        Datasets()
+        local.assert_called_once_with('data')
+        remote.assert_called_once_with()
+        downloader.assert_called_once_with(
+            'data',
+            bucket='mybucket',
+            user='user',
+            password='password'
+        )
+
+    @patch('serenata_toolbox.datasets.LocalDatasets')
+    @patch('serenata_toolbox.datasets.RemoteDatasets')
+    @patch('serenata_toolbox.datasets.Downloader')
+    def test_init_with_local_directory(self, downloader, remote, local):
+        remote.return_value.bucket = 'mybucket'
+        remote.return_value.credentials = dict(user='user', password='password')
+        Datasets('test')
+        local.assert_called_once_with('test')
+        remote.assert_called_once_with()
+        downloader.assert_called_once_with(
+            'test',
+            bucket='mybucket',
+            user='user',
+            password='password'
+        )
+
+    @patch('serenata_toolbox.datasets.LocalDatasets')
+    @patch('serenata_toolbox.datasets.RemoteDatasets')
+    @patch('serenata_toolbox.datasets.Downloader')
+    def test_pending(self, downloader, remote, local):
+        local.return_value.all = (1, 2, 3, 4, 5, 6)
+        remote.return_value.all = (1, 3, 4)
+        expected = (2, 5, 6)
+        datasets = Datasets()
+        self.assertEqual(expected, tuple(datasets.pending))
+
+    @patch('serenata_toolbox.datasets.LocalDatasets')
+    @patch('serenata_toolbox.datasets.RemoteDatasets')
+    @patch('serenata_toolbox.datasets.Downloader')
+    def test_upload_all(self, downloader, remote, local):
+        local.return_value.all = ('file1.xz', 'file2.xz', 'file3.xz')
+        remote.return_value.all = ('file3.xz',)
+        local.return_value.directory = os.path.join('tmp', 'serenata-data')
+        datasets = Datasets()
+        datasets.upload_all()
+        expected = [
+            call(os.path.join('tmp', 'serenata-data', 'file1.xz')),
+            call(os.path.join('tmp', 'serenata-data', 'file2.xz'))
+        ]
+        remote.return_value.upload.assert_has_calls(expected, any_order=True)
+
+
+class TestFetch(TestCase):
+
+    @patch('serenata_toolbox.datasets.Datasets')
+    def test_fetch(self, datasets):
+        fetch('file.xz', 'test')
+        datasets.assert_called_once_with('test')
+        datasets.return_value.downloader.download.assert_called_once_with('file.xz')
+
+    @patch('serenata_toolbox.datasets.Datasets')
+    def test_fetch(self, datasets):
+        fetch('file.xz', 'test')
+        datasets.assert_called_once_with('test')
+        datasets.return_value.downloader.download.assert_called_once_with('file.xz')
+
+    @patch('serenata_toolbox.datasets.Datasets')
+    def test_fetch_latest_backup(self, datasets):
+        fetch_latest_backup('test')
+        self.assertTrue(datasets.return_value.downloader.download.called)

--- a/tests/test_datasets_contextmanager.py
+++ b/tests/test_datasets_contextmanager.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+from unittest.mock import call, patch
+
+from serenata_toolbox.datasets.contextmanager import status_message
+
+class TestContextManager(TestCase):
+
+    @patch('serenata_toolbox.datasets.contextmanager.print')
+    def test_status_message(self, print_):
+        with status_message('test'):
+            pass
+        print_.assert_has_calls((
+            call('test', end=' '),
+            call('Done!')
+        ))

--- a/tests/test_datasets_downloader.py
+++ b/tests/test_datasets_downloader.py
@@ -1,0 +1,118 @@
+import asyncio
+import os
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from aiohttp.test_utils import make_mocked_request
+from aiohttp.web import Response
+
+from serenata_toolbox.datasets.downloader import Downloader
+
+
+class TestDownloader(TestCase):
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        self.assertEqual('bucket', downloader.bucket)
+        self.assertEqual('south', downloader.region)
+        self.assertEqual(os.path.abspath('test'), downloader.target)
+        self.assertEqual(0, downloader.total)
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init_no_bucket(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        with self.assertRaises(RuntimeError):
+            Downloader('test', region_name='south')
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init_no_region(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        with self.assertRaises(RuntimeError):
+            Downloader('test', bucket='bucket')
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init_no_region_no_bucket(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        with self.assertRaises(RuntimeError):
+            Downloader('test')
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init_no_existing_target(self, exists, isdir):
+        exists.return_value = False
+        isdir.return_value = True
+        with self.assertRaises(FileNotFoundError):
+            Downloader('test', bucket='bucket', region_name='south')
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_init_file_target(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            Downloader('test', bucket='bucket', region_name='south')
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_download_no_file(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        self.assertIsNone(downloader.download(''))
+        self.assertIsNone(downloader.download([]))
+
+    @patch.object(Downloader, 'main')
+    @patch('serenata_toolbox.datasets.downloader.asyncio')
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_download_single_file(self, exists, isdir, asyncio_, main):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        downloader.download('test.xz')
+        asyncio_.get_event_loop.assert_called_with()
+        loop = asyncio_.get_event_loop.return_value
+        self.assertTrue(loop.run_until_complete.called)
+        main.assert_called_once_with(loop, ('test.xz',))
+
+    @patch.object(Downloader, 'main')
+    @patch('serenata_toolbox.datasets.downloader.asyncio')
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_download_multiple_files(self, exists, isdir, asyncio_, main):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        downloader.download(range(3))
+        asyncio_.get_event_loop.assert_called_with()
+        loop = asyncio_.get_event_loop.return_value
+        self.assertTrue(loop.run_until_complete.called)
+        main.assert_called_once_with(loop, (1, 2))
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_download_no_file(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        self.assertIsNone(downloader.download(''))
+        self.assertIsNone(downloader.download([]))
+
+    @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
+    @patch('serenata_toolbox.datasets.downloader.os.path.exists')
+    def test_url(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        downloader = Downloader('test', bucket='bucket', region_name='south')
+        expected = 'https://s3-south.amazonaws.com/bucket/test.xz'
+        self.assertEqual(expected, downloader.url('test.xz'))

--- a/tests/test_datasets_local.py
+++ b/tests/test_datasets_local.py
@@ -39,9 +39,9 @@ class TestLocal(TestCase):
         exists.return_value = True
         isdir.return_value = True
         isfile.side_effect = (True, False, True)
-        listdir.return_value = range(3)
+        listdir.return_value = ('0', '1', '2')
         local = LocalDatasets('test')
-        self.assertEqual((0, 2), tuple(local.all))
+        self.assertEqual(('0', '2'), tuple(local.all))
 
 
     @patch('serenata_toolbox.datasets.contextmanager.print')

--- a/tests/test_datasets_local.py
+++ b/tests/test_datasets_local.py
@@ -1,0 +1,82 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from serenata_toolbox.datasets.local import LocalDatasets
+
+
+class TestLocal(TestCase):
+
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_init(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = True
+        local = LocalDatasets('test')
+        self.assertTrue(local.directory.endswith(os.sep + 'test'))
+
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_init_with_file_path(self, exists, isdir):
+        exists.return_value = True
+        isdir.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            LocalDatasets('test')
+
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_init_non_existent_dir(self, exists, isdir):
+        exists.return_value = False
+        isdir.return_value = False
+        with self.assertRaises(FileNotFoundError):
+            LocalDatasets('test')
+
+    @patch('serenata_toolbox.datasets.local.os.listdir')
+    @patch('serenata_toolbox.datasets.local.os.path.isfile')
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_all(self, exists, isdir, isfile, listdir):
+        exists.return_value = True
+        isdir.return_value = True
+        isfile.side_effect = (True, False, True)
+        listdir.return_value = range(3)
+        local = LocalDatasets('test')
+        self.assertEqual((0, 2), tuple(local.all))
+
+
+    @patch('serenata_toolbox.datasets.contextmanager.print')
+    @patch('serenata_toolbox.datasets.local.os.remove')
+    @patch('serenata_toolbox.datasets.local.os.path.isfile')
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_delete(self, exists, isdir, isfile, remove, print_):
+        exists.return_value = True
+        isdir.return_value = True
+        isfile.return_value = True
+        local = LocalDatasets('test')
+        local.delete('42')
+        expected = os.path.join(os.path.abspath('test'), '42')
+        remove.assert_called_once_with(expected)
+
+    @patch('serenata_toolbox.datasets.local.os.path.isfile')
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_delete_dir(self, exists, isdir, isfile):
+        exists.return_value = True
+        isdir.return_value = True
+        isfile.return_value = False
+        local = LocalDatasets('test')
+        with self.assertRaises(FileNotFoundError):
+            local.delete('test')
+
+    @patch('serenata_toolbox.datasets.local.os.remove')
+    @patch('serenata_toolbox.datasets.local.os.path.isfile')
+    @patch('serenata_toolbox.datasets.local.os.path.isdir')
+    @patch('serenata_toolbox.datasets.local.os.path.exists')
+    def test_delete_non_existent_file(self, exists, isdir, isfile, remove):
+        exists.side_effect = (True, False)
+        isdir.return_value = True
+        isfile.return_value = False
+        local = LocalDatasets('test')
+        with self.assertRaises(FileNotFoundError):
+            local.delete('test')

--- a/tests/test_datasets_remote.py
+++ b/tests/test_datasets_remote.py
@@ -1,4 +1,6 @@
 import os
+from configparser import NoSectionError, RawConfigParser
+from functools import partial
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,9 +9,47 @@ from serenata_toolbox.datasets.remote import RemoteDatasets
 
 class TestLocal(TestCase):
 
+    @patch('serenata_toolbox.datasets.remote.print')
+    @patch('serenata_toolbox.datasets.remote.os.path.exists')
+    def test_init_without_config_ini(self, exists, print_):
+        exists.return_value = False
+        remote = RemoteDatasets()
+        with self.assertRaises(AttributeError):
+            remote.s3
+        with self.assertRaises(AttributeError):
+            remote.bucket
+        self.assertTrue(print_.called)
+
+    @patch('serenata_toolbox.datasets.remote.print')
+    @patch('serenata_toolbox.datasets.remote.os.path.exists')
+    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
+    def test_init_with_config_ini_as_directory(self, exists, is_file, print_):
+        exists.return_value = True
+        is_file.return_value = False
+        remote = RemoteDatasets()
+        with self.assertRaises(AttributeError):
+            remote.s3
+        with self.assertRaises(AttributeError):
+            remote.bucket
+        self.assertTrue(print_.called)
+
+    @patch.object(RawConfigParser, 'read')
+    @patch('serenata_toolbox.datasets.remote.print')
+    @patch('serenata_toolbox.datasets.remote.os.path.exists')
+    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
+    def test_init_with_inproper_config_ini(self, exists, is_file, print_, read):
+        exists.return_value = True
+        is_file.return_value = True
+        remote = RemoteDatasets()
+        with self.assertRaises(AttributeError):
+            remote.s3
+        with self.assertRaises(AttributeError):
+            remote.bucket
+        self.assertTrue(print_.called)
+
     @patch('serenata_toolbox.datasets.remote.boto3')
     @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_init(self, raw_config_parser, boto3):
+    def test_successful_init(self, raw_config_parser, boto3):
         raw_config_parser.return_value.get.side_effect = (
             'YOUR_ACCESS_KEY',
             'YOUR_SECRET_KEY',

--- a/tests/test_datasets_remote.py
+++ b/tests/test_datasets_remote.py
@@ -1,47 +1,49 @@
-from configparser import RawConfigParser
+from configparser import NoSectionError, RawConfigParser
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 from serenata_toolbox.datasets.remote import RemoteDatasets
 
 
 class TestRemote(TestCase):
 
-    @patch('serenata_toolbox.datasets.remote.print')
-    @patch('serenata_toolbox.datasets.remote.os.path.exists')
-    def test_init_without_config_ini(self, exists, print_):
-        exists.return_value = False
-        remote = RemoteDatasets()
-        self.assertIsNone(remote.s3)
-        self.assertIsNone(remote.bucket)
-        self.assertTrue(print_.called)
-
-    @patch('serenata_toolbox.datasets.remote.print')
     @patch('serenata_toolbox.datasets.remote.os.path.exists')
     @patch('serenata_toolbox.datasets.remote.os.path.isfile')
-    def test_init_with_config_ini_as_directory(self, exists, is_file, print_):
+    def test_config_exists_when_it_doesnt_exist(self, is_file, exists):
+        exists.return_value = False
+        is_file.return_value = False
+        remote = RemoteDatasets()
+        self.assertFalse(remote.config_exists)
+
+    @patch('serenata_toolbox.datasets.remote.os.path.exists')
+    @patch('serenata_toolbox.datasets.remote.os.path.isfile')
+    def test_config_exists_when_it_is_a_directory(self, is_file, exists):
         exists.return_value = True
         is_file.return_value = False
         remote = RemoteDatasets()
-        self.assertIsNone(remote.s3)
-        self.assertIsNone(remote.bucket)
-        self.assertTrue(print_.called)
+        self.assertFalse(remote.config_exists)
 
-    @patch.object(RawConfigParser, 'read')
-    @patch('serenata_toolbox.datasets.remote.print')
     @patch('serenata_toolbox.datasets.remote.os.path.exists')
     @patch('serenata_toolbox.datasets.remote.os.path.isfile')
-    def test_init_with_inproper_config_ini(self, exists, is_file, print_, read):
+    def test_config_exists_when_it_is_a_file(self, is_file, exists):
         exists.return_value = True
         is_file.return_value = True
+        remote = RemoteDatasets()
+        self.assertTrue(remote.config_exists)
+
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
+    @patch('serenata_toolbox.datasets.remote.print')
+    def test_init_without_config(self, print_, config_exist):
+        config_exist.return_value = False
         remote = RemoteDatasets()
         self.assertIsNone(remote.s3)
         self.assertIsNone(remote.bucket)
         self.assertTrue(print_.called)
 
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
     @patch('serenata_toolbox.datasets.remote.boto3')
     @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_successful_init(self, raw_config_parser, boto3):
+    def test_successful_init(self, raw_config_parser, boto3, config_exists):
         raw_config_parser.return_value.get.side_effect = (
             'YOUR_ACCESS_KEY',
             'YOUR_SECRET_KEY',
@@ -57,45 +59,72 @@ class TestRemote(TestCase):
         self.assertEqual('serenata-de-amor-data', remote.bucket)
         self.assertEqual(credentials, remote.credentials)
 
-    @patch('serenata_toolbox.datasets.remote.boto3')
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
+    def test_bucket_no_config(self, config_exists):
+        config_exists.return_value = False
+        remote = RemoteDatasets()
+        self.assertIsNone(remote.bucket)
+
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
     @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_all(self, raw_config_parser, boto3):
+    def test_bucket_no_section(self, raw_config_parser, config_exists):
+        config_exists.return_value = True
+        raw_config_parser.return_value.get.side_effect = NoSectionError('foo')
+        remote = RemoteDatasets()
+        self.assertIsNone(remote.bucket)
+
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    def test_bucket(self, raw_config_parser, config_exists):
+        config_exists.return_value = True
+        raw_config_parser.return_value.get.return_value = 42
+        remote = RemoteDatasets()
+        self.assertEqual(42, remote.bucket)
+
+    @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    @patch('serenata_toolbox.datasets.remote.boto3')
+    def test_s3(self, boto3, raw_config_parser, config_exists):
+        config_exists.return_value = True
+        remote = RemoteDatasets()
+        remote.credentials = dict(test=42)
+        self.assertIsNotNone(remote.s3)
+        boto3.client.assert_called_once_with('s3', test=42)
+        remote.client = remote.s3
+
+    @patch.object(RemoteDatasets, 'config_exists')
+    @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
+    @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
+    def test_all(self, bucket, s3, config_exists):
         response = {'Contents': [{'Key': 'file1.xz'}, {'Key': 'file2.xz'}]}
-        boto3.client.return_value.list_objects.return_value = response
+        s3.return_value.list_objects.return_value = response
+        bucket.return_value = 'bucket'
         remote = RemoteDatasets()
         self.assertEqual(('file1.xz', 'file2.xz'), tuple(remote.all))
 
     @patch('serenata_toolbox.datasets.contextmanager.print')
-    @patch('serenata_toolbox.datasets.remote.boto3')
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_upload(self, raw_config_parser, boto3, print_):
-        raw_config_parser.return_value.get.side_effect = (
-            'YOUR_ACCESS_KEY',
-            'YOUR_SECRET_KEY',
-            'sa-east-1',
-            'serenata-de-amor-data'
-        )
+    @patch.object(RemoteDatasets, 'config_exists')
+    @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
+    @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
+    def test_upload(self, bucket, s3, config_exists, print_):
+        bucket.return_value = 'serenata-de-amor-data'
         remote = RemoteDatasets()
         remote.upload('/root/serenata/data/42.csv')
-        boto3.client.return_value.upload_file.assert_called_once_with(
+        s3.return_value.upload_file.assert_called_once_with(
             '/root/serenata/data/42.csv',
             'serenata-de-amor-data',
             '42.csv'
         )
 
     @patch('serenata_toolbox.datasets.contextmanager.print')
-    @patch('serenata_toolbox.datasets.remote.boto3')
-    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
-    def test_delete(self, raw_config_parser, boto3, print_):
-        raw_config_parser.return_value.get.side_effect = (
-            'YOUR_ACCESS_KEY',
-            'YOUR_SECRET_KEY',
-            'sa-east-1',
-            'serenata-de-amor-data'
-        )
+    @patch.object(RemoteDatasets, 'config_exists')
+    @patch.object(RemoteDatasets, 's3', new_callable=PropertyMock)
+    @patch.object(RemoteDatasets, 'bucket', new_callable=PropertyMock)
+    def test_delete(self, bucket, s3, config_exists, print_):
+        bucket.return_value = 'serenata-de-amor-data'
         remote = RemoteDatasets()
         remote.delete('42.csv')
-        boto3.client.return_value.delete_object.assert_called_once_with(
+        s3.return_value.delete_object.assert_called_once_with(
             Bucket='serenata-de-amor-data',
             Key='42.csv'
         )

--- a/tests/test_datasets_remote.py
+++ b/tests/test_datasets_remote.py
@@ -1,23 +1,19 @@
-import os
-from configparser import NoSectionError, RawConfigParser
-from functools import partial
+from configparser import RawConfigParser
 from unittest import TestCase
 from unittest.mock import patch
 
 from serenata_toolbox.datasets.remote import RemoteDatasets
 
 
-class TestLocal(TestCase):
+class TestRemote(TestCase):
 
     @patch('serenata_toolbox.datasets.remote.print')
     @patch('serenata_toolbox.datasets.remote.os.path.exists')
     def test_init_without_config_ini(self, exists, print_):
         exists.return_value = False
         remote = RemoteDatasets()
-        with self.assertRaises(AttributeError):
-            remote.s3
-        with self.assertRaises(AttributeError):
-            remote.bucket
+        self.assertIsNone(remote.s3)
+        self.assertIsNone(remote.bucket)
         self.assertTrue(print_.called)
 
     @patch('serenata_toolbox.datasets.remote.print')
@@ -27,10 +23,8 @@ class TestLocal(TestCase):
         exists.return_value = True
         is_file.return_value = False
         remote = RemoteDatasets()
-        with self.assertRaises(AttributeError):
-            remote.s3
-        with self.assertRaises(AttributeError):
-            remote.bucket
+        self.assertIsNone(remote.s3)
+        self.assertIsNone(remote.bucket)
         self.assertTrue(print_.called)
 
     @patch.object(RawConfigParser, 'read')
@@ -41,10 +35,8 @@ class TestLocal(TestCase):
         exists.return_value = True
         is_file.return_value = True
         remote = RemoteDatasets()
-        with self.assertRaises(AttributeError):
-            remote.s3
-        with self.assertRaises(AttributeError):
-            remote.bucket
+        self.assertIsNone(remote.s3)
+        self.assertIsNone(remote.bucket)
         self.assertTrue(print_.called)
 
     @patch('serenata_toolbox.datasets.remote.boto3')

--- a/tests/test_datasets_remote.py
+++ b/tests/test_datasets_remote.py
@@ -1,0 +1,69 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from serenata_toolbox.datasets.remote import RemoteDatasets
+
+
+class TestLocal(TestCase):
+
+    @patch('serenata_toolbox.datasets.remote.boto3')
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    def test_init(self, raw_config_parser, boto3):
+        raw_config_parser.return_value.get.side_effect = (
+            'YOUR_ACCESS_KEY',
+            'YOUR_SECRET_KEY',
+            'sa-east-1',
+            'serenata-de-amor-data'
+        )
+        credentials = {
+            'aws_access_key_id': 'YOUR_ACCESS_KEY',
+            'aws_secret_access_key': 'YOUR_SECRET_KEY',
+            'region_name': 'sa-east-1'
+        }
+        remote = RemoteDatasets()
+        self.assertEqual('serenata-de-amor-data', remote.bucket)
+        self.assertEqual(credentials, remote.credentials)
+
+    @patch('serenata_toolbox.datasets.remote.boto3')
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    def test_all(self, raw_config_parser, boto3):
+        response = {'Contents': [{'Key': 'file1.xz'}, {'Key': 'file2.xz'}]}
+        boto3.client.return_value.list_objects.return_value = response
+        remote = RemoteDatasets()
+        self.assertEqual(('file1.xz', 'file2.xz'), tuple(remote.all))
+
+    @patch('serenata_toolbox.datasets.contextmanager.print')
+    @patch('serenata_toolbox.datasets.remote.boto3')
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    def test_upload(self, raw_config_parser, boto3, print_):
+        raw_config_parser.return_value.get.side_effect = (
+            'YOUR_ACCESS_KEY',
+            'YOUR_SECRET_KEY',
+            'sa-east-1',
+            'serenata-de-amor-data'
+        )
+        remote = RemoteDatasets()
+        remote.upload('/root/serenata/data/42.csv')
+        boto3.client.return_value.upload_file.assert_called_once_with(
+            '/root/serenata/data/42.csv',
+            'serenata-de-amor-data',
+            '42.csv'
+        )
+
+    @patch('serenata_toolbox.datasets.contextmanager.print')
+    @patch('serenata_toolbox.datasets.remote.boto3')
+    @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
+    def test_delete(self, raw_config_parser, boto3, print_):
+        raw_config_parser.return_value.get.side_effect = (
+            'YOUR_ACCESS_KEY',
+            'YOUR_SECRET_KEY',
+            'sa-east-1',
+            'serenata-de-amor-data'
+        )
+        remote = RemoteDatasets()
+        remote.delete('42.csv')
+        boto3.client.return_value.delete_object.assert_called_once_with(
+            Bucket='serenata-de-amor-data',
+            Key='42.csv'
+        )


### PR DESCRIPTION
This PR creates a module to manage datasets — locally and remotely. The novelties are basically described in [`serenata_toolbox/datasets/__init__.py`](https://github.com/datasciencebr/serenata-toolbox/blob/a34aef8487e40adaf644d7945ee0c02b24e25297/serenata_toolbox/datasets/__init__.py#L10-L33), but as a PR message I should highlight ~four~ **five** things:

* This PR replaces `tinys3` (used by the main repo) and uses `boto3` instead because `tinys3` uses `requests` under the hood and [`requests` is unable to upload large files to S3 (more than 10MB)](https://github.com/kennethreitz/requests/issues/2422).
* This PR requires the dependencies to be reinstalled (i.e. drop `tinys3` and install `boto3`) — this changed is in `setup.py`.
* This PR enables the toolbox to _upload_ files, so we need to setup our credentials for that: one has to copy `config.ini.example` as `config.ini` and set them (this is documentes in the new version of the `README.md`).
* When merged we can update `serenata-de-amor/src/backup_datasets.py` to use this module instead.

**UPDATE**

* There are no tests for the `async` methods in the `Downloader` module — once merged I'll open an _Issue_ for that.