### PR TITLE
Add serenata_toolbox.datasets to setup.py

### DIFF
--- a/serenata_toolbox/__init__.py
+++ b/serenata_toolbox/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     license='MIT',
     long_description='Check `Serenata Toolbox at GitHub <{}>`_.'.format(REPO_URL),
     name='serenata-toolbox',
-    packages=['serenata_toolbox'],
+    packages=['serenata_toolbox', 'serenata_toolbox.datasets'],
     url=REPO_URL,
     version='8.0.1'
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     name='serenata-toolbox',
     packages=['serenata_toolbox', 'serenata_toolbox.datasets'],
     url=REPO_URL,
-    version='8.0.1'
+    version='8.0.2'
 )


### PR DESCRIPTION
This seems to be a better fix for #43 — at least worked on a fresh virtualenv ; )

<details>

```console
$ mkvirtualenv teste                                                                                                                          
Using base prefix '/usr/local/var/pyenv/versions/3.6.1'
New python executable in /Users/cuducos/.virtualenvs/teste/bin/python
Installing setuptools, pip, wheel...done.
virtualenvwrapper.user_scripts creating /Users/cuducos/.virtualenvs/teste/bin/predeactivate
virtualenvwrapper.user_scripts creating /Users/cuducos/.virtualenvs/teste/bin/postdeactivate
virtualenvwrapper.user_scripts creating /Users/cuducos/.virtualenvs/teste/bin/preactivate
virtualenvwrapper.user_scripts creating /Users/cuducos/.virtualenvs/teste/bin/postactivate
virtualenvwrapper.user_scripts creating /Users/cuducos/.virtualenvs/teste/bin/get_env_details
pyenv: deactivate: command not found

The `deactivate' command exists in these Python versions:
  anaconda3-4.1.1
  anaconda3-4.1.1/envs/rosie
  anaconda3-4.1.1/envs/serenata_de_amor

(teste)
$ pip install -e git+https://github.com/datasciencebr/serenata-toolbox.git@cuducos-fix-namespace-pkg#egg=serenata-toolbox
Obtaining serenata-toolbox from git+https://github.com/datasciencebr/serenata-toolbox.git@cuducos-fix-namespace-pkg#egg=serenata-toolbox
  Cloning https://github.com/datasciencebr/serenata-toolbox.git (to cuducos-fix-namespace-pkg) to ./.virtualenvs/teste/src/serenata-toolbox
Collecting aiofiles (from serenata-toolbox)
  Using cached aiofiles-0.3.1-py3-none-any.whl
Collecting aiohttp (from serenata-toolbox)
Collecting boto3 (from serenata-toolbox)
  Using cached boto3-1.4.4-py2.py3-none-any.whl
Collecting beautifulsoup4>=4.4 (from serenata-toolbox)
  Using cached beautifulsoup4-4.5.3-py3-none-any.whl
Collecting lxml>=3.6 (from serenata-toolbox)
Collecting pandas>=0.18 (from serenata-toolbox)
 ¹.g/r/git-rebase-todo+                                                                                                                             << buffers
  Using cached pandas-0.19.2-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting tqdm (from serenata-toolbox)
  Using cached tqdm-4.11.2-py2.py3-none-any.whl
Collecting yarl<0.11,>=0.10.0 (from aiohttp->serenata-toolbox)
Collecting chardet (from aiohttp->serenata-toolbox)
  Using cached chardet-3.0.2-py2.py3-none-any.whl
Collecting multidict>=2.1.4 (from aiohttp->serenata-toolbox)
Collecting async-timeout>=1.2.0 (from aiohttp->serenata-toolbox)
  Using cached async_timeout-1.2.0-py3-none-any.whl
Collecting botocore<1.6.0,>=1.5.0 (from boto3->serenata-toolbox)
  Using cached botocore-1.5.44-py2.py3-none-any.whl
Collecting s3transfer<0.2.0,>=0.1.10 (from boto3->serenata-toolbox)
  Using cached s3transfer-0.1.10-py2.py3-none-any.whl
Collecting jmespath<1.0.0,>=0.7.1 (from boto3->serenata-toolbox)
  Using cached jmespath-0.9.2-py2.py3-none-any.whl
Collecting numpy>=1.7.0 (from pandas>=0.18->serenata-toolbox)
  Using cached numpy-1.12.1-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
Collecting python-dateutil>=2 (from pandas>=0.18->serenata-toolbox)
  Using cached python_dateutil-2.6.0-py2.py3-none-any.whl
Collecting pytz>=2011k (from pandas>=0.18->serenata-toolbox)
  Using cached pytz-2017.2-py2.py3-none-any.whl
Collecting docutils>=0.10 (from botocore<1.6.0,>=1.5.0->boto3->serenata-toolbox)
  Using cached docutils-0.13.1-py3-none-any.whl
Requirement already satisfied: six>=1.5 in ./.virtualenvs/teste/lib/python3.6/site-packages (from python-dateutil>=2->pandas>=0.18->serenata-toolbox)
Installing collected packages: aiofiles, multidict, yarl, chardet, async-timeout, aiohttp, docutils, jmespath, python-dateutil, botocore, s3transfer, boto3, beautifulsoup4, lxml, numpy, pytz, pandas, tqdm, serenata-toolbox
  Running setup.py develop for serenata-toolbox
Successfully installed aiofiles-0.3.1 aiohttp-2.0.7 async-timeout-1.2.0 beautifulsoup4-4.5.3 boto3-1.4.4 botocore-1.5.44 chardet-3.0.2 docutils-0.13.1 jmespath-0.9.2 lxml-3.7.3 multidict-2.1.4 numpy-1.12.1 pandas-0.19.2 python-dateutil-2.6.0 pytz-2017.2 s3transfer-0.1.10 serenata-toolbox tqdm-4.11.2 yarl-0.10.0
$ python                                                                                                                                      
Python 3.6.1 (default, Mar 28 2017, 11:51:28)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import serenata_toolbox.datasets
>>> exit()
```
</details>