### PR TITLE
add zip_safe=False to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'Topic :: Utilities',
     ],
     description='Toolbox for Serenata de Amor project',
+    zip_safe=False,
     install_requires=[
         'aiofiles',
         'aiohttp',

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
     name='serenata-toolbox',
     packages=['serenata_toolbox.chamber_of_deputies', 'serenata_toolbox.datasets'],
     url=REPO_URL,
-    version='9.0.1'
+    version='9.0.2'
 )


### PR DESCRIPTION
The zip_safe flag can be used to force or prevent zip Archive creation. In general you probably don’t want your packages to be installed as zip files because some tools do not support them and they make debugging a lot harder.

To maintain sanity, this flag should be included in all the setup.py files of all datasciencebr python packages .