### PR TITLE
Configure landscape.io

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,6 @@
+python-targets: 3
+max-line-length: 120
+strictness: veryhigh
+doc-warnings: true
+ignore-paths:
+  - docs


### PR DESCRIPTION
As we're using [landscape.io](http://landscape.io) for CI when it comes to code quality, I suggest we configure it so:

* It targets only Python 3 (as we do not support Python 2)
* IMHO we could stop at 80 chars, as PEP8 suggests, but I'm afraid people would disagree so I stretched the max line length to 120
* Set [strictness](https://prospector.landscape.io//en/master/profiles.html?highlight=veryhigh#strictness) to `veryhigh` (which means more quality checks)
* Add warnings about missing `docstrings` (this is very helpful thinking of #23)
* Ignores files from `docs/`