### PR TITLE
Ignoring virtualenv from coverage analysis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,2 @@
 [run]
   source = serenata_toolbox
-  omit =
-      */virtualenv/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+  source = serenata_toolbox
+  omit =
+      */virtualenv/*


### PR DESCRIPTION
This PR fixes the issue #75, by adding a coverage configuration file to fix the Coveralls inaccurate metrics (due to the unnecessary analysis of third-party libraries). Below, there is a screenshot showing the Coveralls statistics dashboard after applying the aforementioned configurations in the forked project:

![screen shot 2017-05-24 at 2 09 01 pm](https://cloud.githubusercontent.com/assets/4705127/26416910/dd795aec-408d-11e7-83dd-4286c06afc00.png)

It is also possible to check this very same dashboard [here](https://coveralls.io/github/othman853/serenata-toolbox).

