### PR TITLE
Cache pip on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 3.5
+cache: pip
 install:
   - python setup.py develop
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python: 3.5
 cache: pip
 install:
-  - python setup.py develop
+  - pip install -U pip wheel
+  - pip install --requirement=$TRAVIS_BUILD_DIR/requirements.txt
   - pip install coveralls
 script: coverage run -m unittest discover tests
 after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -125,4 +125,3 @@ Source Code
 Feel free to fork, evaluate and contribute to this project.
 
 Source: https://github.com/datasciencebr/serenata-toolbox/
-

--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,4 @@ Source Code
 Feel free to fork, evaluate and contribute to this project.
 
 Source: https://github.com/datasciencebr/serenata-toolbox/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+aiofiles
+aiohttp
+boto3
+beautifulsoup4>=4.4
+lxml>=3.6
+pandas>=0.18
+tqdm


### PR DESCRIPTION
While working on another PR I noticed that the build is taking 9+min to complete and a good chunk of that is packages installation. I gave a shot at [enabling `pip` cache](https://github.com/datasciencebr/serenata-toolbox/pull/79/commits/fa7db8556f4948593d3d6ade2d5fc9136e77e189) but it wasn't enough as the [following build](https://travis-ci.org/datasciencebr/serenata-toolbox/builds/238591201) based on this [dummy commit](https://github.com/datasciencebr/serenata-toolbox/pull/79/commits/2407424d01c659128863ec5fea5b9757d82e5528) took the same amount of time since dependencies are declared on `setup.py` and that does not seem to leverage the `pip` cache.

Based on [this post](https://atchai.com/blog/faster-ci/#python-dependencies:39217f0d4cf249d478c580725f3796e8), I [introduced a `requirements.txt`](https://github.com/datasciencebr/serenata-toolbox/pull/79/commits/f3cb82ea8ef3fa91a408dacae930893472d952be) based on `setup.py` and updated `install` commands. This change got the [build down to ~1min](https://travis-ci.org/datasciencebr/serenata-toolbox/builds/238593948) 🤘 

I'm not sure what are the side effect of these changes neither why this is not the default for travis but I guess we could give it a shot in order to get faster feedback on CI. What do you guys think?

As a side note, have u guys considered automating releases from travis? We could even automate the execution of integration tests as part of that 💭 