### PR TITLE
Allow the user to provide a year list to filter the datasets

### DIFF
--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -7,18 +7,19 @@ import numpy as np
 import pandas as pd
 from .reimbursements import Reimbursements
 
+
 class Dataset:
 
-    YEARS = [n for n in range(2009, date.today().year+1)]
+    AVAILABLE_YEARS = [year for year in range(2009, date.today().year + 1)]
 
-    def __init__(self, path):
+    def __init__(self, path, years=AVAILABLE_YEARS):
         self.path = path
-
+        self.years = years
 
     def fetch(self):
         base_url = "http://www.camara.leg.br/cotas/Ano-{}.csv.zip"
 
-        for year in self.YEARS:
+        for year in self.years:
             zip_file_path = os.path.join(self.path, "Ano-{}.zip".format(year))
             url = base_url.format(year)
             urlretrieve(url, zip_file_path)
@@ -30,28 +31,24 @@ class Dataset:
         urlretrieve('http://www2.camara.leg.br/transparencia/cota-para-exercicio-da-atividade-parlamentar/explicacoes-sobre-o-formato-dos-arquivos-xml',
                     os.path.join(self.path, 'datasets-format.html'))
 
-
     def convert_to_csv(self):
         # deprecated but still here so we don't break poor Rosie (for now)
         pass
 
-
     def translate(self):
-        for year in self.YEARS:
+        for year in self.years:
             csv_path = os.path.join(self.path, 'Ano-{}.csv'.format(year))
             self.__translate_file(csv_path)
-
 
     def clean(self):
         reimbursements = Reimbursements(self.path)
         dataset = reimbursements.group(reimbursements.receipts)
         reimbursements.write_reimbursement_file(dataset)
 
-
     def __translate_file(self, csv_path):
         output_file_path = csv_path \
-                           .replace('.csv', '.xz') \
-                           .replace('Ano-', 'reimbursements-')
+            .replace('.csv', '.xz') \
+            .replace('Ano-', 'reimbursements-')
 
         data = pd.read_csv(csv_path,
                            encoding='utf-8',
@@ -126,7 +123,7 @@ class Dataset:
         )
 
         for code, name in subquotas:
-            data.loc[data['subquota_number']==code, ['subquota_description']] = name
+            data.loc[data['subquota_number'] == code, ['subquota_description']] = name
 
         data.to_csv(output_file_path, compression='xz', index=False,
                     encoding='utf-8')

--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -14,7 +14,7 @@ class Dataset:
 
     def __init__(self, path, years=AVAILABLE_YEARS):
         self.path = path
-        self.years = years
+        self.years = years if isinstance(years, list) else [years]
 
     def fetch(self):
         base_url = "http://www.camara.leg.br/cotas/Ano-{}.csv.zip"

--- a/serenata_toolbox/chamber_of_deputies/reimbursements.py
+++ b/serenata_toolbox/chamber_of_deputies/reimbursements.py
@@ -13,7 +13,7 @@ class Reimbursements:
         'index': False
     }
 
-    YEARS = [n for n in range(2009, date.today().year+1)]
+    YEARS = [year for year in range(2009, date.today().year+1)]
 
     def __init__(self, path):
         self.path = path

--- a/serenata_toolbox/federal_senate/dataset.py
+++ b/serenata_toolbox/federal_senate/dataset.py
@@ -12,7 +12,7 @@ class Dataset:
 
     def __init__(self, path, years=AVAILABLE_YEARS):
         self.path = path
-        self.years = years
+        self.years = years if isinstance(years, list) else [years]
 
     def fetch(self):
         retrieved_files = []

--- a/serenata_toolbox/federal_senate/dataset.py
+++ b/serenata_toolbox/federal_senate/dataset.py
@@ -8,19 +8,17 @@ import pandas as pd
 class Dataset:
     URL = 'http://www.senado.gov.br/transparencia/LAI/verba/{}.csv'
 
-    LAST_YEAR = date.today().year + 1
+    AVAILABLE_YEARS = [year for year in range(2008, date.today().year + 1)]
 
-    def __init__(self, path, first_year=2008, last_year=LAST_YEAR):
+    def __init__(self, path, years=AVAILABLE_YEARS):
         self.path = path
-        self.first_year = first_year
-        self.last_year = last_year
-        self.year_range = range(first_year, last_year)
+        self.years = years
 
     def fetch(self):
         retrieved_files = []
         not_found_files = []
 
-        for year in self.year_range:
+        for year in self.years:
             url = self.URL.format(year)
             file_path = os.path.join(self.path, 'federal-senate-{}.csv'.format(year))
             try:
@@ -66,7 +64,7 @@ class Dataset:
         return reimbursement_path
 
     def _filename_generator(self, extension):
-        return ['federal-senate-{}.{}'.format(year, extension) for year in self.year_range]
+        return ['federal-senate-{}.{}'.format(year, extension) for year in self.years]
 
     def _cleanup_dataset(self, dataset):
         dataset['date'] = pd.to_datetime(dataset['date'], errors='coerce')

--- a/tests/journey/test_chamber_of_deputies_dataset.py
+++ b/tests/journey/test_chamber_of_deputies_dataset.py
@@ -14,7 +14,7 @@ class TestChamberOfDeputiesDataset(TestCase):
         self.path = mkdtemp(prefix='serenata-')
         print(self.path)
         self.subject = Dataset(self.path)
-        self.years = [n for n in range(2009, date.today().year + 1)]
+        self.years = [year for year in range(2009, date.today().year + 1)]
 
 
     def tearDown(self):

--- a/tests/journey/test_federal_senate_dataset.py
+++ b/tests/journey/test_federal_senate_dataset.py
@@ -13,14 +13,14 @@ class TestJourneyFederalSenateDataset(TestCase):
     def test_journey_federal_senate_dataset(self):
         # fetch_saves_raw_files
         self.subject.fetch()
-        federal_senate_csv_files = ['federal-senate-{}.csv'.format(year) for year in self.subject.year_range]
+        federal_senate_csv_files = ['federal-senate-{}.csv'.format(year) for year in self.subject.years]
         for federal_senate_csv_file in federal_senate_csv_files:
             file_path = os.path.join(self.path, federal_senate_csv_file)
             self.assertTrue(os.path.exists(file_path), 'fetch_saves_raw_files')
 
         # translate_creates_english_versions_for_every_csv
         self.subject.translate()
-        federal_senate_xz_files = ['federal-senate-{}.xz'.format(year) for year in self.subject.year_range]
+        federal_senate_xz_files = ['federal-senate-{}.xz'.format(year) for year in self.subject.years]
         for federal_senate_xz_file in federal_senate_xz_files:
             file_path = os.path.join(self.path, federal_senate_xz_file)
             self.assertTrue(os.path.exists(file_path), 'translate_creates_english_versions_for_every_csv')

--- a/tests/unit/test_federal_senate_dataset.py
+++ b/tests/unit/test_federal_senate_dataset.py
@@ -22,7 +22,7 @@ class TestFederalSenateDataset(TestCase):
         retrieved_files, not_found_files = self.subject.fetch()
 
         self.assertTrue(mocked_url_etrieve.called)
-        self.assertEqual(mocked_url_etrieve.call_count, len(self.subject.year_range))
+        self.assertEqual(mocked_url_etrieve.call_count, len(self.subject.years))
         for retrieved_file, expected_file in zip(
                 retrieved_files, self.expected_files):
 
@@ -30,7 +30,7 @@ class TestFederalSenateDataset(TestCase):
 
     def test_fetch_not_found_files_from_S3(self):
         self.path = gettempdir()
-        self.subject = Dataset(self.path, 2007, 2008)
+        self.subject = Dataset(self.path, [2007])
 
         retrieved_files, not_found_files = self.subject.fetch()
 
@@ -41,8 +41,7 @@ class TestFederalSenateDataset(TestCase):
 
     def test_dataset_translation(self):
         self.subject = Dataset(os.path.join('tests', 'fixtures', 'csv'),
-                                            2008,
-                                            2009)
+                               [2008])
 
         expected_files = ['federal-senate-2008.csv']
 
@@ -55,8 +54,7 @@ class TestFederalSenateDataset(TestCase):
 
     def test_if_translation_happened_as_expected(self):
         self.subject = Dataset(os.path.join('tests', 'fixtures', 'csv'),
-                                            2008,
-                                            2009)
+                               [2008])
 
         file_path = os.path.join(self.subject.path, 'federal-senate-2008.csv')
         federal_senate_2008 = pd.read_csv(file_path,
@@ -79,8 +77,7 @@ class TestFederalSenateDataset(TestCase):
 
     def test_dataset_translation_failing_to_find_file(self):
         self.subject = Dataset(os.path.join('tests', 'fixtures', 'csv'),
-                                            2007,
-                                            2008)
+                               [2007])
 
         expected_files = ['federal-senate-2007.csv']
 
@@ -93,8 +90,7 @@ class TestFederalSenateDataset(TestCase):
 
     def test_dataset_cleanup(self):
         self.subject = Dataset(os.path.join('tests', 'fixtures', 'xz'),
-                                            2009,
-                                            2010)
+                               [2009])
 
         reimbursement_path = self.subject.clean()
 


### PR DESCRIPTION
One step in the direction to allow users to make non-standard uses of the datasets.

In the Whistleblower repository, will remove the need of copying and pasting a whole file - [whistleblower/get_dataset.py](https://github.com/datasciencebr/whistleblower/blob/25c4c8932228143e61b0f8eb6a764aeabbaffa7a/whistleblower/get_dataset.py) - for just a few changes.