### PR TITLE
add config file lookup feature

### DIFF
--- a/serenata_toolbox/datasets/helpers.py
+++ b/serenata_toolbox/datasets/helpers.py
@@ -72,7 +72,7 @@ def find_config(name='config.ini'):
         joined = os.path.join(path, name)
 
         # return config file absolute path if exists
-        if os.path.exists(joined):
+        if os.path.exists(joined) and os.path.isfile(joined):
             return os.path.abspath(joined)
 
         path = os.path.join('..', path)

--- a/serenata_toolbox/datasets/helpers.py
+++ b/serenata_toolbox/datasets/helpers.py
@@ -56,3 +56,30 @@ def save_to_csv(df, data_dir, name):
     today = datetime.strftime(datetime.now(), '%Y-%m-%d')
     file_path = os.path.join(data_dir, '{}-{}.xz'.format(today, name))
     df.to_csv(file_path, **CSV_PARAMS)
+
+
+# Utility for config file lookup (credits to fabric fabfile lookup)
+
+def find_config(name='config.ini'):
+    """
+    :param name: config file name (defaults to 'config.ini')
+    """
+    # start in cwd and work downwards towards filesystem root
+    path = '.'
+    # Stop before falling off root of filesystem (should be platform
+    # agnostic)
+    while os.path.split(os.path.abspath(path))[1]:
+        joined = os.path.join(path, name)
+
+        # return config file absolute path if exists
+        if os.path.exists(joined):
+            return os.path.abspath(joined)
+
+        path = os.path.join('..', path)
+
+    # if config not found fallback on tests expected behavior
+    # wich is to return the filename to be used at remote
+    # config_exists class property.
+    # a future refactor could be to return None and not use
+    # config exists anymore
+    return name

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -5,6 +5,7 @@ import os
 import boto3
 
 from serenata_toolbox.datasets.contextmanager import status_message
+from serenata_toolbox.datasets.helpers import find_config
 
 
 class RemoteDatasets:
@@ -14,6 +15,7 @@ class RemoteDatasets:
     def __init__(self):
         self.credentials = None
         self.client = None
+        self.config = find_config(self.CONFIG)
 
         if not self.config_exists:
             print('Could not find {} file.'.format(self.CONFIG))
@@ -22,7 +24,7 @@ class RemoteDatasets:
             return
 
         settings = configparser.RawConfigParser()
-        settings.read(self.CONFIG)
+        settings.read(self.config)
         self.settings = partial(settings.get, 'Amazon')
 
         try:
@@ -52,7 +54,7 @@ class RemoteDatasets:
 
     @property
     def config_exists(self):
-        return all((os.path.exists(self.CONFIG), os.path.isfile(self.CONFIG)))
+        return all((os.path.exists(self.config), os.path.isfile(self.config)))
 
     @property
     def bucket(self):

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.0.2'
+    version='12.0.3'
 )

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -90,22 +90,45 @@ class TestDatasetsHelpersDataframes(TestCase):
 class TestDatasetsHelpersConfigLookup(TestCase):
 
     def setUp(self):
-        self.root = os.path.abspath(tempfile.mkdtemp())
-        self.subfolder = os.path.abspath(tempfile.mkdtemp(dir=self.root))
-        self.config_file = os.path.join(self.root, 'config.ini')
+        # good case
+        self.root1 = os.path.abspath(tempfile.mkdtemp())
+        self.subfolder = os.path.abspath(tempfile.mkdtemp(dir=self.root1))
+        self.config_file = os.path.join(self.root1, 'config.ini')
         self.cwd = os.getcwd()
-
         open(self.config_file, 'a').close()
-        os.chdir(self.subfolder)
+
+        # not found case
+        self.root2 = os.path.abspath(tempfile.mkdtemp())
+
+        # not a file case
+        self.root3 = os.path.abspath(tempfile.mkdtemp())
+        self.config_folder = os.path.join(self.root3, 'config.ini')
+        os.makedirs(self.config_folder)
+
 
     def tearDown(self):
         os.chdir(self.cwd)
         os.remove(self.config_file)
         os.rmdir(self.subfolder)
-        os.rmdir(self.root)
+        os.rmdir(self.root1)
+        os.rmdir(self.root2)
+        os.rmdir(self.config_folder)
+        os.rmdir(self.root3)
 
     def test_find_config(self):
+        os.chdir(self.subfolder)
+
         self.assertEqual(helpers.find_config(), self.config_file)
+
+    def test_find_config_not_found(self):
+        os.chdir(self.root2)
+
+        self.assertEqual(helpers.find_config(), 'config.ini')
+
+    def test_find_config_a_file(self):
+        os.chdir(self.root3)
+
+        self.assertEqual(helpers.find_config(), 'config.ini')
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -90,8 +90,8 @@ class TestDatasetsHelpersDataframes(TestCase):
 class TestDatasetsHelpersConfigLookup(TestCase):
 
     def setUp(self):
-        self.root = tempfile.mkdtemp()
-        self.subfolder = tempfile.mkdtemp(dir=self.root)
+        self.root = os.path.abspath(tempfile.mkdtemp())
+        self.subfolder = os.path.abspath(tempfile.mkdtemp(dir=self.root))
         self.config_file = os.path.join(self.root, 'config.ini')
         self.cwd = os.getcwd()
 

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from datetime import datetime
 from unittest import main, TestCase
 from unittest.mock import patch
@@ -7,6 +8,7 @@ import pandas as pd
 import numpy as np
 
 from serenata_toolbox.datasets import helpers
+
 
 class TestDatasetsHelpersXml(TestCase):
 
@@ -51,6 +53,7 @@ class TestDatasetsHelpersXml(TestCase):
 
         self.assertEqual(expected, extracted)
 
+
 class TestDatasetsHelpersDataframes(TestCase):
 
     def test_translate_column(self):
@@ -82,6 +85,28 @@ class TestDatasetsHelpersDataframes(TestCase):
             encoding='utf-8',
             index=False
         )
+
+
+class TestDatasetsHelpersConfigLookup(TestCase):
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+        self.subfolder = tempfile.mkdtemp(dir=self.root)
+        self.config_file = os.path.join(self.root, 'config.ini')
+        self.cwd = os.getcwd()
+
+        open(self.config_file, 'a').close()
+        os.chdir(self.subfolder)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        os.remove(self.config_file)
+        os.rmdir(self.subfolder)
+        os.rmdir(self.root)
+
+    def test_find_config(self):
+        self.assertEqual(helpers.find_config(), self.config_file)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -91,18 +91,18 @@ class TestDatasetsHelpersConfigLookup(TestCase):
 
     def setUp(self):
         # good case
-        self.root1 = os.path.realpath(tempfile.mkdtemp())
-        self.subfolder = os.path.relpath(tempfile.mkdtemp(dir=self.root1))
-        self.config_file = os.path.join(self.root1, 'config.ini')
+        self.root = os.path.realpath(tempfile.mkdtemp())
+        self.subfolder = os.path.relpath(tempfile.mkdtemp(dir=self.root))
+        self.config_file = os.path.join(self.root, 'config.ini')
         self.cwd = os.getcwd()
         open(self.config_file, 'a').close()
 
         # not found case
-        self.root2 = os.path.relpath(tempfile.mkdtemp())
+        self.root_not_found = os.path.relpath(tempfile.mkdtemp())
 
         # not a file case
-        self.root3 = os.path.relpath(tempfile.mkdtemp())
-        self.config_folder = os.path.join(self.root3, 'config.ini')
+        self.root_not_a_file = os.path.relpath(tempfile.mkdtemp())
+        self.config_folder = os.path.join(self.root_not_a_file, 'config.ini')
         os.makedirs(self.config_folder)
 
 
@@ -110,10 +110,10 @@ class TestDatasetsHelpersConfigLookup(TestCase):
         os.chdir(self.cwd)
         os.remove(self.config_file)
         os.rmdir(self.subfolder)
-        os.rmdir(self.root1)
-        os.rmdir(self.root2)
+        os.rmdir(self.root)
+        os.rmdir(self.root_not_found)
         os.rmdir(self.config_folder)
-        os.rmdir(self.root3)
+        os.rmdir(self.root_not_a_file)
 
     def test_find_config(self):
         os.chdir(self.subfolder)
@@ -121,12 +121,12 @@ class TestDatasetsHelpersConfigLookup(TestCase):
         self.assertEqual(helpers.find_config(), self.config_file)
 
     def test_find_config_not_found(self):
-        os.chdir(self.root2)
+        os.chdir(self.root_not_found)
 
         self.assertEqual(helpers.find_config(), 'config.ini')
 
     def test_find_config_a_file(self):
-        os.chdir(self.root3)
+        os.chdir(self.root_not_a_file)
 
         self.assertEqual(helpers.find_config(), 'config.ini')
 

--- a/tests/unit/test_datasets_helpers.py
+++ b/tests/unit/test_datasets_helpers.py
@@ -91,17 +91,17 @@ class TestDatasetsHelpersConfigLookup(TestCase):
 
     def setUp(self):
         # good case
-        self.root1 = os.path.abspath(tempfile.mkdtemp())
-        self.subfolder = os.path.abspath(tempfile.mkdtemp(dir=self.root1))
+        self.root1 = os.path.realpath(tempfile.mkdtemp())
+        self.subfolder = os.path.relpath(tempfile.mkdtemp(dir=self.root1))
         self.config_file = os.path.join(self.root1, 'config.ini')
         self.cwd = os.getcwd()
         open(self.config_file, 'a').close()
 
         # not found case
-        self.root2 = os.path.abspath(tempfile.mkdtemp())
+        self.root2 = os.path.relpath(tempfile.mkdtemp())
 
         # not a file case
-        self.root3 = os.path.abspath(tempfile.mkdtemp())
+        self.root3 = os.path.relpath(tempfile.mkdtemp())
         self.config_folder = os.path.join(self.root3, 'config.ini')
         os.makedirs(self.config_folder)
 


### PR DESCRIPTION
Hey, i made this PR in order to fix issue #46.

I've added a lookup function inspired on [fabric's fabfile discovery](https://github.com/fabric/fabric/blob/master/fabric/main.py#L106-L117) to go down from current directory to root looking for a `config.ini` file. If the file is not found it returns the informed file name.

I leave a comment on that function talking about the possibility of returning None on a future refactor deprecating the `config_exists` remote attribute. But it probably need some checking on possible code that rely on that.