### PR TITLE
Adds Operação Serenata de Amor e-mail to setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ REPO_URL = 'http://github.com/datasciencebr/serenata-toolbox'
 
 setup(
     author='Serenata de Amor',
+    author_email='op.serenatadeamor@gmail.com',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.0.3'
+    version='12.0.4'
 )


### PR DESCRIPTION
This should fix the warning generated while running the `sdist` command for PyPI release. 

`warning: check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too`