### PR TITLE
Remove mehtod `convert_to_csv` from  CEAP dataset

### DIFF
--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -28,10 +28,6 @@ class Dataset:
         urlretrieve('http://www2.camara.leg.br/transparencia/cota-para-exercicio-da-atividade-parlamentar/explicacoes-sobre-o-formato-dos-arquivos-xml',
                     os.path.join(self.path, 'datasets-format.html'))
 
-    def convert_to_csv(self):
-        # deprecated but still here so we don't break poor Rosie (for now)
-        pass
-
     def translate(self):
         for year in self.years:
             csv_path = os.path.join(self.path, 'Ano-{}.csv'.format(year))

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.0.5'
+    version='12.0.6'
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
The purpose is remove unnecessary method of CEAP dataset to make it cleaner.

**What was done to achieve this purpose?**
I just removed the method and checked if Rosie do not use this method anymore.

**How to test if it really works?**
Just running unit test you will able to see that nothing breaks in Serenata Toolbox.

**Who can help reviewing it?**
@jtemporal @anaschwendler could help with Rosie's knowledge.