### PR TITLE
Add option to update all the datasets

### DIFF
--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -83,7 +83,7 @@ def fetch_latest_backup(destination_path, force_all=False):
     else:
         files = tuple(
             f for f in datasets.downloader.LATEST
-            if not os.path.exists(os.path.join(destination_path, dataset_file))
+            if not os.path.exists(os.path.join(destination_path, f))
         )
 
     if not files:

--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -75,13 +75,16 @@ def fetch(filename, destination_path):
     return datasets.downloader.download(filename)
 
 
-def fetch_latest_backup(destination_path):
+def fetch_latest_backup(destination_path, force_all=False):
     datasets = Datasets(destination_path)
 
-    files = tuple(
-        dataset_file for dataset_file in datasets.downloader.LATEST
-        if not os.path.exists(os.path.join(destination_path, dataset_file))
-    )
+    if force_all:
+        files = datasets.downloader.LATEST
+    else:
+        files = tuple(
+            f for f in datasets.downloader.LATEST
+            if not os.path.exists(os.path.join(destination_path, dataset_file))
+        )
 
     if not files:
         print('You already have all the latest datasets! Nothing to download.')

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.1.9'
+    version='12.2.0'
 )

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -85,3 +85,11 @@ class TestFetch(TestCase):
         os_path_exists.side_effect = [False, True, False]
         fetch_latest_backup('test')
         datasets.return_value.downloader.download.assert_called_once_with(('file1', 'file3'))
+
+    @patch('os.path.exists')
+    @patch('serenata_toolbox.datasets.Datasets')
+    def test_fetch_latest_backup_with_force_all(self, datasets, os_path_exists):
+        datasets().downloader.LATEST = ('file1', 'file2', 'file3')
+        os_path_exists.side_effect = [False, True, False]
+        fetch_latest_backup('test', force_all=True)
+        datasets.return_value.downloader.download.assert_called_once_with(('file1', 'file2', 'file3'))


### PR DESCRIPTION
This PR contains commits from #132, so please merge #132 first.

If the user wants to download all the datasets, even if they are already downloaded, he can pass an option `--all` to the command `./setup`. Otherwise, only the missing datasets will be downloaded.