### PR TITLE
Fix float convertion

### DIFF
--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -71,11 +71,11 @@ class Dataset:
         }
 
     def fetch(self):
-        base_url = "http://www.camara.leg.br/cotas/Ano-{}.csv.zip"
+        base_url = 'http://www.camara.leg.br/cotas/Ano-{}.csv.zip'
         retrieved_files = []
 
         for year in self.years:
-            zip_file_path = os.path.join(self.path, "Ano-{}.zip".format(year))
+            zip_file_path = os.path.join(self.path, 'Ano-{}.zip'.format(year))
             url = base_url.format(year)
             urlretrieve(url, zip_file_path)
             retrieved_files.append(zip_file_path)

--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -75,6 +75,7 @@ class Dataset:
         retrieved_files = []
 
         for year in self.years:
+            print('Downloading dataset from {}…'.format(year))
             zip_file_path = os.path.join(self.path, 'Ano-{}.zip'.format(year))
             url = base_url.format(year)
             urlretrieve(url, zip_file_path)
@@ -91,6 +92,7 @@ class Dataset:
         return retrieved_files
 
     def _extract_zip_file(self, zip_file_path):
+        print('Extracting {}…'.format(zip_file_path))
         zip_file = ZipFile(zip_file_path, 'r')
         zip_file.extractall(self.path)
         zip_file.close()
@@ -99,6 +101,7 @@ class Dataset:
 
     def translate(self):
         for year in self.years:
+            print('Translating dataset from {}…'.format(year))
             csv_path = os.path.join(self.path, 'Ano-{}.csv'.format(year))
             self._translate_file(csv_path)
 
@@ -137,6 +140,7 @@ class Dataset:
             dtype=dtype
         )
 
+        print('Cleaning {}…'.format(csv_path))
         data = pd.read_csv(csv_path, **kwargs)
 
         data['vlrRestituicao'] = pd.to_numeric(

--- a/serenata_toolbox/chamber_of_deputies/dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/dataset.py
@@ -112,17 +112,38 @@ class Dataset:
             .replace('.csv', '.xz') \
             .replace('Ano-', 'reimbursements-')
 
-        data = pd.read_csv(csv_path,
-                           encoding='utf-8',
-                           delimiter=";",
-                           quoting=csv.QUOTE_NONE,
-                           dtype={'ideDocumento': np.str,
-                                  'idecadastro': np.str,
-                                  'nuCarteiraParlamentar': np.str,
-                                  'codLegislatura': np.str,
-                                  'txtCNPJCPF': np.str,
-                                  'numRessarcimento': np.str},
-                           )
+        strings = (
+            'codLegislatura',
+            'ideDocumento',
+            'idecadastro',
+            'nuCarteiraParlamentar',
+            'numRessarcimento'
+            'txtCNPJCPF',
+            'txtDescricaoEspecificacao',
+            'vlrRestituicao'  # raises warning if directly coerced to float
+        )
+        floats = (
+            'vlrDocumento',
+            'vlrGlosa',
+            'vlrLiquido',
+        )
+        dtype = {key: np.str for key in strings}
+        dtype.update({key: np.float for key in floats})
+        kwargs = dict(
+            encoding='utf-8',
+            delimiter=';',
+            quoting=csv.QUOTE_NONE,
+            decimal=',',
+            dtype=dtype
+        )
+
+        data = pd.read_csv(csv_path, **kwargs)
+
+        data['vlrRestituicao'] = pd.to_numeric(
+            data['vlrRestituicao'],
+            errors='coerce',
+            downcast='float'
+        )  # raises warning if directly coerced to float on dtype
 
         data.rename(columns=self.translate_columns, inplace=True)
 

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.1.3'
+    version='12.1.4'
 )

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.1.2'
+    version='12.1.3'
 )


### PR DESCRIPTION
This fixes a `float` conversion that was passing unnoticed and [breaking Rosie](https://github.com/datasciencebr/rosie/issues/77).

This is how I tested it.

In the toolbox environment:

1. Changed to (or create) `cuducos-fix-float-convertion` branch
2. Pull the commits from this PR

In Rosie's environment:

1. Uninstalled the current version of the toolbox: `$ pip uninstall serenata_toolbox`
2. Install my local toolbox instead: `$ pip install -e <path to serenata_toolbox>`
3. Run Rosie: `$ python rosie.py run chamber_of_deputies ../serenata-de-amor/research/data`

**Important**: I'm not sure this PR is really working, I believe it is because it goes further the point @jtemporal reported, however it throws an error typical of memory error… so I can't be sure. 