### PR TITLE
Fix asyncio error in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.3.0'
+    version='12.3.1'
 )

--- a/tests/unit/test_datasets_downloader.py
+++ b/tests/unit/test_datasets_downloader.py
@@ -1,10 +1,10 @@
 import asyncio
 import os
+from concurrent.futures import TimeoutError
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from aiohttp import ClientSession
-from aiohttp.client_exceptions import TimeoutError
 from serenata_toolbox.datasets.downloader import Downloader
 
 
@@ -134,7 +134,7 @@ class TestDownloader(TestCase):
     @patch('serenata_toolbox.datasets.downloader.os.path.isdir')
     @patch('serenata_toolbox.datasets.downloader.os.path.exists')
     @async_test
-    def test_download_timeout(self, exists, isdir):  
+    def test_download_timeout(self, exists, isdir):
         exists.return_value = True
         isdir.return_value = True
         with self.assertRaises(TimeoutError):


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Last build with the updated version of `aiohttp` has [broken our tests CI](https://travis-ci.org/datasciencebr/serenata-toolbox/builds/309092425). 

**What was done to achieve this purpose?**
This PR adapts our code to the new error architecture of current version of `aiohttp`, using `TimeoutError` from `concurrent.futures` instead of `aiohttp.client_exceptions`.

**How to test if it really works?**
`$ pytest` or try to download something and hope the server takes too long to cause a timeout ; )

**Who can help reviewing it?**
@anaschwendler 