### PR TITLE
Use logs instead of print (extends #156)

### DIFF
--- a/serenata_toolbox/__init__.py
+++ b/serenata_toolbox/__init__.py
@@ -1,0 +1,18 @@
+import logging
+import os
+import sys
+
+
+LEVEL = logging.DEBUG if os.environ.get('DEBUG') else logging.INFO
+LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+
+# get a default logger to the project
+log = logging.getLogger()
+log.setLevel(LEVEL)
+
+# make this log send messages to stdout
+output = logging.StreamHandler(sys.stdout)
+output.setLevel(LEVEL)
+output.setFormatter(logging.Formatter(LOG_FORMAT))
+log.addHandler(output)

--- a/serenata_toolbox/chamber_of_deputies/deputies_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/deputies_dataset.py
@@ -1,9 +1,9 @@
 import urllib
-import logging
 import xml.etree.ElementTree as ET
 
 import pandas as pd
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.helpers import (
     save_to_csv,
     translate_column,
@@ -83,7 +83,7 @@ def fetch_deputies(data_dir):
 
     holders = df.condition == 'Holder'
     substitutes = df.condition == 'Substitute'
-    logging.info("Total deputies:", len(df))
-    logging.info("Holder deputies:", len(df[holders]))
-    logging.info("Substitute deputies:", len(df[substitutes]))
+    log.info("Total deputies:", len(df))
+    log.info("Holder deputies:", len(df[holders]))
+    log.info("Substitute deputies:", len(df[substitutes]))
     return df

--- a/serenata_toolbox/chamber_of_deputies/official_missions_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/official_missions_dataset.py
@@ -33,8 +33,7 @@ class OfficialMissionsDataset:
 
         records = []
         for two_months_range in self._generate_ranges(start_date, end_date):
-            if os.environ.get('DEBUG') == '1':
-                logging.debug(two_months_range)
+            logging.debug(two_months_range)
             for record in self._fetch_missions_for_range(two_months_range[0], two_months_range[1]):
                 records.append(record)
 

--- a/serenata_toolbox/chamber_of_deputies/official_missions_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/official_missions_dataset.py
@@ -1,5 +1,3 @@
-import logging
-import os
 import urllib
 
 from datetime import timedelta
@@ -8,6 +6,7 @@ import pandas as pd
 
 from bs4 import BeautifulSoup
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.helpers import (
     save_to_csv,
     translate_column,
@@ -33,7 +32,7 @@ class OfficialMissionsDataset:
 
         records = []
         for two_months_range in self._generate_ranges(start_date, end_date):
-            logging.debug(two_months_range)
+            log.debug(two_months_range)
             for record in self._fetch_missions_for_range(two_months_range[0], two_months_range[1]):
                 records.append(record)
 

--- a/serenata_toolbox/chamber_of_deputies/presences_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/presences_dataset.py
@@ -36,8 +36,7 @@ class PresencesDataset:
         :param date_start: (str) date in the format dd/mm/yyyy
         :param date_end: (str) date in the format dd/mm/yyyy
         """
-        if os.environ.get('DEBUG') == '1':
-            logging.debug("Fetching data for {} deputies from {} -> {}".format(len(deputies), start_date, end_date))
+        logging.debug("Fetching data for {} deputies from {} -> {}".format(len(deputies), start_date, end_date))
 
         records = self._all_presences(deputies, start_date, end_date)
 
@@ -58,8 +57,7 @@ class PresencesDataset:
     def _all_presences(self, deputies, start_date, end_date):
         error_count = 0
         for i, deputy in deputies.iterrows():
-            if os.environ.get('DEBUG') == '1':
-                logging.debug(i, deputy.congressperson_name, deputy.congressperson_document)
+            logging.debug(i, deputy.congressperson_name, deputy.congressperson_document)
             url = self.URL.format(start_date, end_date, deputy.congressperson_document)
             xml = self._try_fetch_xml(10, url)
 
@@ -72,8 +70,7 @@ class PresencesDataset:
 
             time.sleep(self.sleep_interval)
 
-        if os.environ.get('DEBUG') == '1':
-            logging.debug("\nErrored fetching", error_count, "deputy presences")
+        logging.debug("\nErrored fetching", error_count, "deputy presences")
 
     def _try_fetch_xml(self, attempts, url):
         while attempts > 0:
@@ -84,14 +81,14 @@ class PresencesDataset:
                 # 500 seems to be the error code for "no data found for the
                 # params provided"
                 if err.code == 500:
-                    logging.error("SKIP")
+                    logging.info("Skipping [HTTP Status 500] {}".format(url))
                     return None
                 time.sleep(self.sleep_interval / 2)
                 attempts -= 1
                 if attempts > 0:
                     logging.info("Trying again", attempts)
                 else:
-                    logging.error("FAIL")
+                    logging.error("FAIL {}".format(url))
             except socket.error as socketerror:
                 logging.error("Socket error:", socketerror)
                 time.sleep(self.sleep_interval * 10)
@@ -99,7 +96,7 @@ class PresencesDataset:
                 if attempts > 0:
                     logging.info("Trying again", attempts)
                 else:
-                    logging.error("FAIL")
+                    logging.error("FAIL {}".format(url))
 
     @staticmethod
     def _parse_deputy_presences(root):

--- a/serenata_toolbox/chamber_of_deputies/session_start_times_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/session_start_times_dataset.py
@@ -1,10 +1,10 @@
-import logging
 import os
 import urllib
 import xml.etree.ElementTree as ET
 
 import pandas as pd
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.helpers import (
     save_to_csv,
     xml_extract_datetime,
@@ -35,7 +35,7 @@ class SessionStartTimesDataset:
 
     def _all_start_times(self, pivot, session_dates):
         for date in session_dates:
-            logging.debug(date.strftime("%d/%m/%Y"))
+            log.debug(date.strftime("%d/%m/%Y"))
             file = urllib.request.urlopen(self.URL.format(date.strftime("%d/%m/%Y"), pivot))
             tree = ET.ElementTree(file=file)
             for session in tree.getroot().findall('.//sessaoDia'):
@@ -56,7 +56,7 @@ def fetch_session_start_times(data_dir, pivot, session_dates):
     df = session_start_times.fetch(pivot, session_dates)
     save_to_csv(df, data_dir, "session-start-times")
 
-    logging.info("Dates requested:", len(session_dates))
+    log.info("Dates requested:", len(session_dates))
     found = pd.to_datetime(df['date'], format="%Y-%m-%d %H:%M:%S").dt.date.unique()
-    logging.info("Dates found:", len(found))
+    log.info("Dates found:", len(found))
     return df

--- a/serenata_toolbox/chamber_of_deputies/session_start_times_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/session_start_times_dataset.py
@@ -35,8 +35,7 @@ class SessionStartTimesDataset:
 
     def _all_start_times(self, pivot, session_dates):
         for date in session_dates:
-            if os.environ.get('DEBUG') == '1':
-                logging.debug(date.strftime("%d/%m/%Y"))
+            logging.debug(date.strftime("%d/%m/%Y"))
             file = urllib.request.urlopen(self.URL.format(date.strftime("%d/%m/%Y"), pivot))
             tree = ET.ElementTree(file=file)
             for session in tree.getroot().findall('.//sessaoDia'):

--- a/serenata_toolbox/chamber_of_deputies/speeches_dataset.py
+++ b/serenata_toolbox/chamber_of_deputies/speeches_dataset.py
@@ -1,9 +1,9 @@
-import logging
-import xml.etree.ElementTree as ET
 import urllib
+import xml.etree.ElementTree as ET
 
 import pandas as pd
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.helpers import (
     save_to_csv,
     xml_extract_date,
@@ -69,7 +69,7 @@ class SpeechesDataset:
                     try:
                         speech_started_at = xml_extract_datetime(speech, 'horaInicioDiscurso')
                     except ValueError as value_error_exception:
-                        logging.warning("Error parsing speech start time for {} - {}/{} on {}\n{}".format(
+                        log.warning("Error parsing speech start time for {} - {}/{} on {}\n{}".format(
                             speech_speaker_name,
                             speech_speaker_party,
                             speech_speaker_state,

--- a/serenata_toolbox/datasets/__init__.py
+++ b/serenata_toolbox/datasets/__init__.py
@@ -1,6 +1,6 @@
 import os
-import logging
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.downloader import Downloader
 from serenata_toolbox.datasets.local import LocalDatasets
 from serenata_toolbox.datasets.remote import RemoteDatasets
@@ -91,6 +91,6 @@ def fetch_latest_backup(destination_path, force_all=False):
         )
 
     if not files:
-        logging.info('You already have all the latest datasets! Nothing to download.')
+        log.info('You already have all the latest datasets! Nothing to download.')
 
     return datasets.downloader.download(files)

--- a/serenata_toolbox/datasets/remote.py
+++ b/serenata_toolbox/datasets/remote.py
@@ -1,11 +1,10 @@
-import logging
-
+import os
 import configparser
 from functools import partial
-import os
 
 import boto3
 
+from serenata_toolbox import log
 from serenata_toolbox.datasets.contextmanager import status_message
 from serenata_toolbox.datasets.helpers import find_config
 
@@ -20,9 +19,9 @@ class RemoteDatasets:
         self.config = find_config(self.CONFIG)
 
         if not self.config_exists:
-            logging.info('Could not find {} file.'.format(self.CONFIG))
-            logging.info('You need Amazon section in it to interact with S3')
-            logging.info('(Check config.ini.example if you need a reference.)')
+            log.info('Could not find {} file.'.format(self.CONFIG))
+            log.info('You need Amazon section in it to interact with S3')
+            log.info('(Check config.ini.example if you need a reference.)')
             return
 
         settings = configparser.RawConfigParser()
@@ -45,14 +44,14 @@ class RemoteDatasets:
                     'to the region (sa-east-1). Please update your config.ini '
                     'replacing regions like `s3-sa-east-1` by `sa-east-1`.'
                 )
-                logging.info(msg)
+                log.info(msg)
 
         except configparser.NoSectionError:
             msg = (
                 'You need an Amazon section in {} to interact with S3 '
                 '(Check config.ini.example if you need a reference.)'
             )
-            logging.info(msg.format(self.CONFIG))
+            log.info(msg.format(self.CONFIG))
 
     @property
     def config_exists(self):

--- a/serenata_toolbox/federal_senate/dataset.py
+++ b/serenata_toolbox/federal_senate/dataset.py
@@ -1,10 +1,11 @@
-import logging
 import os.path
 from datetime import date
 from urllib.error import HTTPError, URLError
 from urllib.request import urlretrieve
 
 import pandas as pd
+
+from serenata_toolbox import log
 
 
 class Dataset:
@@ -26,17 +27,17 @@ class Dataset:
             try:
                 urlretrieve(url, file_path)
             except HTTPError as http_error_exception:
-                logging.error('We failed to reach the server')
-                logging.error('Error code ', http_error_exception.reason)
-                logging.error("While fetching, Seranata Toolbox didn't find file: {} \n{}".format(
+                log.error('We failed to reach the server')
+                log.error('Error code ', http_error_exception.reason)
+                log.error("While fetching, Seranata Toolbox didn't find file: {} \n{}".format(
                     file_path,
                     http_error_exception)
                 )
                 raise http_error_exception
             except URLError as url_error_exception:
-                logging.error("The server couldn\'t fulfill the request.")
-                logging.error('Reason: ', url_error_exception.reason)
-                logging.error("While fetching, Seranata Toolbox didn't find file: {} \n{}".format(
+                log.error("The server couldn\'t fulfill the request.")
+                log.error('Reason: ', url_error_exception.reason)
+                log.error("While fetching, Seranata Toolbox didn't find file: {} \n{}".format(
                     file_path,
                     url_error_exception)
                 )
@@ -56,7 +57,7 @@ class Dataset:
             try:
                 self._translate_file(csv_path)
             except FileNotFoundError as file_not_found_error:
-                logging.error("While translating, Seranata Toolbox didn't find file: {} \n{}".format(
+                log.error("While translating, Seranata Toolbox didn't find file: {} \n{}".format(
                     csv_path,
                     file_not_found_error)
                 )

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.3.1'
+    version='12.3.2'
 )

--- a/tests/unit/test_datasets_remote.py
+++ b/tests/unit/test_datasets_remote.py
@@ -32,7 +32,7 @@ class TestRemote(TestCase):
         self.assertTrue(remote.config_exists)
 
     @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.logging.info')
+    @patch('serenata_toolbox.datasets.remote.log.info')
     def test_init_without_config(self, print_, config_exist):
         config_exist.return_value = False
         remote = RemoteDatasets()
@@ -41,7 +41,7 @@ class TestRemote(TestCase):
         self.assertTrue(print_.called)
 
     @patch.object(RemoteDatasets, 'config_exists', new_callable=PropertyMock)
-    @patch('serenata_toolbox.datasets.remote.logging.info')
+    @patch('serenata_toolbox.datasets.remote.log.info')
     @patch('serenata_toolbox.datasets.remote.boto3')
     @patch('serenata_toolbox.datasets.remote.configparser.RawConfigParser')
     def test_init_with_old_config(self, raw_config_parser, boto3, print_, config_exists):


### PR DESCRIPTION
This PR is based on #162 in order to be able to run tests without error. **So it's recommended to review #162 before this one**.

---

**What is the purpose of this Pull Request?**

This is a follow up for #156  — after code review I'm afraid @jcemelanda couldn't get back to the code, so we jumped in because we wanted these enhancements so bad ; ) In addition we added a custom logger to be used anywhere and this log is automatically outputting messages to `stdout`.

**What was done to achieve this purpose?**

* When using `log.debug` we deleted the `if os.environ.get('DEBUG')` because it was already explicit it's a debug message/log
* We enhanced some error/info messages with failing URL and useful information about the event being registered in the log
* Added and setup a logger a `serenata_toolbox/__init__.py` to be imported and used within other modules

**How to test if it really works?**
Tests cannot fail, plus running some scripts (the 11 changed) and checking logs are there, for example:

<img width="770" alt="pasted_image_29_11_17_18_53" src="https://user-images.githubusercontent.com/4732915/33398925-cd4ef73c-d537-11e7-9063-573310354b36.png">

**Who can help reviewing it?**

@anaschwendler 