### PR TITLE
Refactor deputies dataset tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.4.1'
+    version='12.3.2'
 )

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.3.1'
+    version='12.4.1'
 )

--- a/tests/journey/test_chamber_of_deputies_deputies_dataset.py
+++ b/tests/journey/test_chamber_of_deputies_deputies_dataset.py
@@ -11,22 +11,22 @@ class TestDeputiesDataset(TestCase):
 
     def test_fetch(self):
         df = self.subject.fetch()
-        actualColumns = df.columns
+        actualColumns = set(df.columns)
 
-        expectedColumns = [
+        expectedColumns = {
             'congressperson_id', 'budget_id', 'condition',
             'congressperson_document', 'civil_name', 'congressperson_name',
             'picture_url', 'gender', 'state', 'party', 'phone_number', 'email'
-        ]
+        }
         self.assertTrue((np.array(expectedColumns) == np.array(actualColumns)).all())
 
-        expectedGenders = ['male', 'female']
-        actualGenders = df.gender.unique()
-        self.assertTrue((np.array(expectedGenders) == np.array(actualGenders)).all())
+        expectedGenders = {'male', 'female'}
+        actualGenders = set(df.gender.unique())
+        self.assertTrue(expectedGenders, actualGenders)
 
-        expectedConditions = ['Holder', 'Substitute']
-        actualConditions = df.condition.unique()
-        self.assertTrue((np.array(expectedConditions) == np.array(actualConditions)).all())
+        expectedConditions = {'Substitute', 'Holder'}
+        actualConditions = set(df.condition.unique())
+        self.assertEqual(expectedConditions, actualConditions)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Since yesterday we've been needing some fixes in our tests. @cuducos has fixed the `asyncio` tests in #162 and another little bug has appeared with the sets of tests in deputies dataset order. This PR fix that error.

**What was done to achieve this purpose?**
Basically we refactored the lists to sets structure, so its order don't matter, since the problem was that the order was inverted.

**How to test if it really works?**
Run the tests:
```console
$ pip install pytest pytest-cov
$ pytest
```

**Who can help reviewing it?**
@cuducos 

