### PR TITLE
Add electoral campaign donations datasets

### DIFF
--- a/serenata_toolbox/datasets/downloader.py
+++ b/serenata_toolbox/datasets/downloader.py
@@ -43,6 +43,9 @@ class Downloader:
         '2017-06-17-official-missions.xz',
         '2017-07-04-reimbursements.xz',
         '2017-07-20-tse-candidates.xz',
+        '2017-11-30-donations-candidates.xz',
+        '2017-11-30-donations-committees.xz',
+        '2017-11-30-donations-parties.xz',
     )
 
     def __init__(self, target, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.3.2'
+    version='12.4.0'
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Add the electoral campaign donation datasets to the toolbox downloader.

**What was done to achieve this purpose?**
Outside the repo I uploaded the `.xz` files to S3 and here I added the files to the `LATEST` constant.

**How to test if it really works?**

```
from serenata_toolbox.datasets import fetch, fetch_latest_backup
files = (
   '2017-11-30-donations-candidates.xz',
    '2017-11-30-donations-committees.xz',
   '2017-11-30-donations-parties.xz'
)
for filename in files:
    fetch(filename, 'data/')
```

And check if the filer were downloaded successfully ; )

**Who can help reviewing it?**
@anaschwendler 