### PR TITLE
Fix log import bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,11 @@ setup(
     long_description='Check `Serenata Toolbox at GitHub <{}>`_.'.format(REPO_URL),
     name='serenata-toolbox',
     packages=[
+        'serenata_toolbox',
         'serenata_toolbox.federal_senate',
         'serenata_toolbox.chamber_of_deputies',
         'serenata_toolbox.datasets'
     ],
     url=REPO_URL,
-    version='12.3.0'
+    version='12.4.2'
 )


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
#163 introduced a bug (#173) related to `from serenata_toolbox import log`. The problem was that the main module `serenata_toolbox` wasn't listed as a package in the `setup.py`.

**What was done to achieve this purpose?**
I added `serenata_toolbox` as a package in `setup.py`

**How to test if it really works?**

1. Fetch this branch
1. Create a fresh new virtualenv
1. Go to a different directory than the one you use to develop `serenata-toolbox`
1. `pip install <path to your serenata-toolbox directory>`
1. `python -c 'from serenata_toolbox import log'` should throw no errors

**Who can help reviewing it?**
@anaschwendler @jtemporal 
